### PR TITLE
Fix empty MarchRobot by constructing it via the initializer list

### DIFF
--- a/march_hardware/include/march_hardware/MarchRobot.h
+++ b/march_hardware/include/march_hardware/MarchRobot.h
@@ -23,8 +23,6 @@ public:
 
   MarchRobot(::std::vector<Joint> jointList, ::std::string ifName, int ecatCycleTime);
 
-  MarchRobot();
-
   void startEtherCAT();
 
   void stopEtherCAT();

--- a/march_hardware/src/MarchRobot.cpp
+++ b/march_hardware/src/MarchRobot.cpp
@@ -14,14 +14,10 @@
 
 namespace march4cpp
 {
-MarchRobot::MarchRobot()
-{
-}
-
 MarchRobot::MarchRobot(::std::vector<Joint> jointList, ::std::string ifName, int ecatCycleTime)
 {
-  this->jointList = jointList;
-  ethercatMaster.reset(new EthercatMaster(&jointList, ifName, this->getMaxSlaveIndex(), ecatCycleTime));
+  this->jointList = std::move(jointList);
+  ethercatMaster.reset(new EthercatMaster(&this->jointList, ifName, this->getMaxSlaveIndex(), ecatCycleTime));
 }
 
 void MarchRobot::startEtherCAT()

--- a/march_hardware_builder/test/TestAllowedRobots.cpp
+++ b/march_hardware_builder/test/TestAllowedRobots.cpp
@@ -15,11 +15,15 @@ class AllowedRobotTest : public ::testing::Test
 protected:
 };
 
-TEST_F(AllowedRobotTest, TestMarch3)
+TEST_F(AllowedRobotTest, TestMarch3Creation)
 {
   HardwareBuilder hardwareBuilder = HardwareBuilder(AllowedRobot::march3);
-  march4cpp::MarchRobot march3;
-  ASSERT_NO_THROW(march3 = hardwareBuilder.createMarchRobot());
+  ASSERT_NO_THROW(march4cpp::MarchRobot march3 = hardwareBuilder.createMarchRobot());
+}
+
+TEST_F(AllowedRobotTest, TestMarch3Values)
+{
+  march4cpp::MarchRobot march3 = HardwareBuilder(AllowedRobot::march3).createMarchRobot();
 
   march4cpp::Encoder RHJenc = march4cpp::Encoder(16, 22134, 43436, 24515, 0.05);
   march4cpp::Encoder LHJenc = march4cpp::Encoder(16, 9746, 31557, 11830, 0.05);
@@ -63,9 +67,7 @@ TEST_F(AllowedRobotTest, TestMarch3)
   ASSERT_EQ(actualRobot, march3);
 }
 
-TEST_F(AllowedRobotTest, TestTestSetup)
+TEST_F(AllowedRobotTest, TestTestSetupCreation)
 {
-  HardwareBuilder hardwareBuilder = HardwareBuilder(AllowedRobot::testsetup);
-  march4cpp::MarchRobot testSetup;
-  ASSERT_NO_THROW(testSetup = hardwareBuilder.createMarchRobot());
+  ASSERT_NO_THROW(march4cpp::MarchRobot testSetup = HardwareBuilder(AllowedRobot::testsetup).createMarchRobot());
 }

--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -98,7 +98,7 @@ void MarchHardwareInterface::init()
     effort_joint_interface_.registerHandle(jointEffortHandle);
 
     // Enable high voltage on the IMC
-    //    joint.getIMotionCube().goToOperationEnabled();
+    joint.getIMotionCube().goToOperationEnabled();
   }
 
   registerInterface(&joint_state_interface_);

--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -17,10 +17,9 @@ using joint_limits_interface::PositionJointSoftLimitsInterface;
 
 namespace march_hardware_interface
 {
-MarchHardwareInterface::MarchHardwareInterface(ros::NodeHandle& nh, AllowedRobot robotName) : nh_(nh)
+MarchHardwareInterface::MarchHardwareInterface(ros::NodeHandle& nh, AllowedRobot robotName)
+  : nh_(nh), marchRobot(HardwareBuilder(robotName).createMarchRobot())
 {
-  HardwareBuilder hardwareBuilder = HardwareBuilder(robotName);
-  this->marchRobot = hardwareBuilder.createMarchRobot();
   init();
   controller_manager_.reset(new controller_manager::ControllerManager(this, nh_));
   nh_.param("/march/hardware_interface/loop_hz", loop_hz_, 0.1);
@@ -99,7 +98,7 @@ void MarchHardwareInterface::init()
     effort_joint_interface_.registerHandle(jointEffortHandle);
 
     // Enable high voltage on the IMC
-    joint.getIMotionCube().goToOperationEnabled();
+    //    joint.getIMotionCube().goToOperationEnabled();
   }
 
   registerInterface(&joint_state_interface_);


### PR DESCRIPTION
Fix a bug where the hardware_interface would refer to an empty object instead of the one created