### PR TITLE
Toggle joint actuation from .yaml file

### DIFF
--- a/march_hardware/include/march_hardware/Joint.h
+++ b/march_hardware/include/march_hardware/Joint.h
@@ -12,7 +12,7 @@ class Joint
 {
 private:
   std::string name;
-  bool actuate;
+  bool allowActuation;
   IMotionCube iMotionCube;
   TemperatureGES temperatureGES;
 
@@ -41,7 +41,7 @@ public:
   friend bool operator==(const Joint& lhs, const Joint& rhs)
   {
     return lhs.name == rhs.name && lhs.iMotionCube == rhs.iMotionCube && lhs.temperatureGES == rhs.temperatureGES &&
-           lhs.actuate == rhs.actuate;
+           lhs.allowActuation == rhs.allowActuation;
   }
 
   friend bool operator!=(const Joint& lhs, const Joint& rhs)
@@ -52,7 +52,7 @@ public:
   friend ::std::ostream& operator<<(std::ostream& os, const Joint& joint)
   {
     return os << "name: " << joint.name << ", "
-              << "actuate: " << joint.actuate<< ", "
+              << "actuate: " << joint.allowActuation<< ", "
               << "imotioncube: " << joint.iMotionCube << ","
               << "temperatureges: " << joint.temperatureGES;
   }

--- a/march_hardware/include/march_hardware/Joint.h
+++ b/march_hardware/include/march_hardware/Joint.h
@@ -18,9 +18,9 @@ private:
 
 public:
   // TODO(Tim) pass by reference or pointer instead of making copy
-  Joint(std::string name, bool actuate, TemperatureGES temperatureGES, IMotionCube iMotionCube);
-  Joint(std::string name, bool actuate, TemperatureGES temperatureGES);
-  Joint(std::string name, bool actuate, IMotionCube iMotionCube);
+  Joint(std::string name, bool allowActuation, TemperatureGES temperatureGES, IMotionCube iMotionCube);
+  Joint(std::string name, bool allowActuation, TemperatureGES temperatureGES);
+  Joint(std::string name, bool allowActuation, IMotionCube iMotionCube);
 
   void initialize(int ecatCycleTime);
   void actuateRad(float targetPositionRad);
@@ -52,7 +52,7 @@ public:
   friend ::std::ostream& operator<<(std::ostream& os, const Joint& joint)
   {
     return os << "name: " << joint.name << ", "
-              << "actuate: " << joint.allowActuation<< ", "
+              << "allowActuation: " << joint.allowActuation<< ", "
               << "imotioncube: " << joint.iMotionCube << ","
               << "temperatureges: " << joint.temperatureGES;
   }

--- a/march_hardware/include/march_hardware/Joint.h
+++ b/march_hardware/include/march_hardware/Joint.h
@@ -12,14 +12,15 @@ class Joint
 {
 private:
   std::string name;
+  bool actuate;
   IMotionCube iMotionCube;
   TemperatureGES temperatureGES;
 
 public:
   // TODO(Tim) pass by reference or pointer instead of making copy
-  Joint(std::string name, TemperatureGES temperatureGES, IMotionCube iMotionCube);
-  Joint(std::string name, TemperatureGES temperatureGES);
-  Joint(std::string name, IMotionCube iMotionCube);
+  Joint(std::string name, bool actuate, TemperatureGES temperatureGES, IMotionCube iMotionCube);
+  Joint(std::string name, bool actuate, TemperatureGES temperatureGES);
+  Joint(std::string name, bool actuate, IMotionCube iMotionCube);
 
   void initialize(int ecatCycleTime);
   void actuateRad(float targetPositionRad);
@@ -34,11 +35,13 @@ public:
 
   bool hasIMotionCube();
   bool hasTemperatureGES();
+  bool canActuate();
 
   /** @brief Override comparison operator */
   friend bool operator==(const Joint& lhs, const Joint& rhs)
   {
-    return lhs.name == rhs.name && lhs.iMotionCube == rhs.iMotionCube && lhs.temperatureGES == rhs.temperatureGES;
+    return lhs.name == rhs.name && lhs.iMotionCube == rhs.iMotionCube && lhs.temperatureGES == rhs.temperatureGES &&
+           lhs.actuate == rhs.actuate;
   }
 
   friend bool operator!=(const Joint& lhs, const Joint& rhs)
@@ -49,6 +52,7 @@ public:
   friend ::std::ostream& operator<<(std::ostream& os, const Joint& joint)
   {
     return os << "name: " << joint.name << ", "
+              << "actuate: " << joint.actuate<< ", "
               << "imotioncube: " << joint.iMotionCube << ","
               << "temperatureges: " << joint.temperatureGES;
   }

--- a/march_hardware/src/Joint.cpp
+++ b/march_hardware/src/Joint.cpp
@@ -5,23 +5,23 @@
 
 namespace march4cpp
 {
-Joint::Joint(std::string name, bool actuate, TemperatureGES temperatureGES, IMotionCube iMotionCube)
+Joint::Joint(std::string name, bool allowActuation, TemperatureGES temperatureGES, IMotionCube iMotionCube)
   : temperatureGES(temperatureGES), iMotionCube(iMotionCube)
 {
   this->name = std::move(name);
-  this->allowActuation = actuate;
+  this->allowActuation = allowActuation;
 }
 
-Joint::Joint(std::string name, bool actuate, TemperatureGES temperatureGES) : temperatureGES(temperatureGES)
+Joint::Joint(std::string name, bool allowActuation, TemperatureGES temperatureGES) : temperatureGES(temperatureGES)
 {
   this->name = std::move(name);
-  this->allowActuation = actuate;
+  this->allowActuation = allowActuation;
 }
-Joint::Joint(std::string name, bool actuate, IMotionCube iMotionCube) : iMotionCube(iMotionCube)
+Joint::Joint(std::string name, bool allowActuation, IMotionCube iMotionCube) : iMotionCube(iMotionCube)
 
 {
   this->name = std::move(name);
-  this->allowActuation = actuate;
+  this->allowActuation = allowActuation;
 }
 
 void Joint::initialize(int ecatCycleTime)

--- a/march_hardware/src/Joint.cpp
+++ b/march_hardware/src/Joint.cpp
@@ -38,7 +38,9 @@ void Joint::initialize(int ecatCycleTime)
 
 void Joint::actuateRad(float targetPositionRad)
 {
-  // TODO(BaCo) check that the position is allowed and does not exceed (torque) limits.
+  ROS_ASSERT_MSG(this->actuate, "Joint %s is not allowed to actuate, yet its actuate method has been called.",
+          this->name.c_str());
+    // TODO(BaCo) check that the position is allowed and does not exceed (torque) limits.
   this->iMotionCube.actuateRad(targetPositionRad);
 }
 

--- a/march_hardware/src/Joint.cpp
+++ b/march_hardware/src/Joint.cpp
@@ -5,20 +5,23 @@
 
 namespace march4cpp
 {
-Joint::Joint(std::string name, TemperatureGES temperatureGES, IMotionCube iMotionCube)
+Joint::Joint(std::string name, bool actuate, TemperatureGES temperatureGES, IMotionCube iMotionCube)
   : temperatureGES(temperatureGES), iMotionCube(iMotionCube)
 {
   this->name = std::move(name);
+  this->actuate = actuate;
 }
 
-Joint::Joint(std::string name, TemperatureGES temperatureGES) : temperatureGES(temperatureGES)
+Joint::Joint(std::string name, bool actuate, TemperatureGES temperatureGES) : temperatureGES(temperatureGES)
 {
   this->name = std::move(name);
+  this->actuate = actuate;
 }
-Joint::Joint(std::string name, IMotionCube iMotionCube) : iMotionCube(iMotionCube)
+Joint::Joint(std::string name, bool actuate, IMotionCube iMotionCube) : iMotionCube(iMotionCube)
 
 {
   this->name = std::move(name);
+  this->actuate = actuate;
 }
 
 void Joint::initialize(int ecatCycleTime)
@@ -95,5 +98,10 @@ bool Joint::hasIMotionCube()
 bool Joint::hasTemperatureGES()
 {
   return this->temperatureGES.getSlaveIndex() != -1;
+}
+
+bool Joint::canActuate()
+{
+  return this->actuate;
 }
 }  // namespace march4cpp

--- a/march_hardware/src/Joint.cpp
+++ b/march_hardware/src/Joint.cpp
@@ -9,19 +9,19 @@ Joint::Joint(std::string name, bool actuate, TemperatureGES temperatureGES, IMot
   : temperatureGES(temperatureGES), iMotionCube(iMotionCube)
 {
   this->name = std::move(name);
-  this->actuate = actuate;
+  this->allowActuation = actuate;
 }
 
 Joint::Joint(std::string name, bool actuate, TemperatureGES temperatureGES) : temperatureGES(temperatureGES)
 {
   this->name = std::move(name);
-  this->actuate = actuate;
+  this->allowActuation = actuate;
 }
 Joint::Joint(std::string name, bool actuate, IMotionCube iMotionCube) : iMotionCube(iMotionCube)
 
 {
   this->name = std::move(name);
-  this->actuate = actuate;
+  this->allowActuation = actuate;
 }
 
 void Joint::initialize(int ecatCycleTime)
@@ -38,7 +38,7 @@ void Joint::initialize(int ecatCycleTime)
 
 void Joint::actuateRad(float targetPositionRad)
 {
-  ROS_ASSERT_MSG(this->actuate, "Joint %s is not allowed to actuate, yet its actuate method has been called.",
+  ROS_ASSERT_MSG(this->allowActuation, "Joint %s is not allowed to actuate, yet its actuate method has been called.",
           this->name.c_str());
     // TODO(BaCo) check that the position is allowed and does not exceed (torque) limits.
   this->iMotionCube.actuateRad(targetPositionRad);
@@ -104,6 +104,6 @@ bool Joint::hasTemperatureGES()
 
 bool Joint::canActuate()
 {
-  return this->actuate;
+  return this->allowActuation;
 }
 }  // namespace march4cpp

--- a/march_hardware/src/main.cpp
+++ b/march_hardware/src/main.cpp
@@ -18,37 +18,40 @@
 
 int main(int argc, char** argv)
 {
-    march4cpp::TemperatureGES temperatureGES = march4cpp::TemperatureGES(1, 0);
-    // TODO(ISHA, MARTIJN) double-check these numbers.
-    march4cpp::Encoder enc = march4cpp::Encoder(16, 37961, 59649, 39717, 0.05);
-    march4cpp::IMotionCube imc = march4cpp::IMotionCube(2, enc);
-    march4cpp::Joint temp = march4cpp::Joint("test_joint", temperatureGES, imc);
+  march4cpp::TemperatureGES temperatureGES = march4cpp::TemperatureGES(1, 0);
+  // TODO(ISHA, MARTIJN) double-check these numbers.
+  march4cpp::Encoder enc = march4cpp::Encoder(16, 37961, 59649, 39717, 0.05);
+  march4cpp::IMotionCube imc = march4cpp::IMotionCube(2, enc);
+  march4cpp::Joint temp = march4cpp::Joint("test_joint", true, temperatureGES, imc);
 
-    std::vector<march4cpp::Joint> jointList;
-    jointList.push_back(temp);
+  std::vector<march4cpp::Joint> jointList;
+  jointList.push_back(temp);
 
-    int ecatCycleTime = 4;  // milliseconds
-    march4cpp::MarchRobot march4 = march4cpp::MarchRobot(jointList, "enp2s0", ecatCycleTime);
-    march4.startEtherCAT();
+  int ecatCycleTime = 4;  // milliseconds
+  march4cpp::MarchRobot march4 = march4cpp::MarchRobot(jointList, "enp2s0", ecatCycleTime);
+  march4.startEtherCAT();
 
-     if (!march4.isEthercatOperational())
-     {
-       ROS_FATAL("EtherCAT is not operational");
-       return 0;
-     }
+  if (!march4.isEthercatOperational())
+  {
+    ROS_FATAL("EtherCAT is not operational");
+    return 0;
+  }
 
-     ros::init(argc, argv, "dummy");
-     ros::NodeHandle nh;
-     ros::Rate rate(10);
+  ros::init(argc, argv, "dummy");
+  ros::NodeHandle nh;
+  ros::Rate rate(10);
 
-     // Uncomment to allow actuation.
-     march4.getJoint("test_joint").getIMotionCube().goToOperationEnabled();
-     ROS_INFO("march4 initialized");
+  if (march4.getJoint("test_joint").canActuate())
+  {
+    march4.getJoint("test_joint").getIMotionCube().goToOperationEnabled();
+  }
 
-     ROS_INFO_STREAM("Angle: " << march4.getJoint("test_joint").getAngleRad());
-     march4.getJoint("test_joint").getIMotionCube().actuateRadFixedSpeed(0.6, 0.1);
-     march4.getJoint("test_joint").getIMotionCube().actuateRadFixedSpeed(1, 0.2);
-     march4.getJoint("test_joint").getIMotionCube().actuateRadFixedSpeed(0.6, 0.3);
+  ROS_INFO("march4 initialized");
+
+  ROS_INFO_STREAM("Angle: " << march4.getJoint("test_joint").getAngleRad());
+  march4.getJoint("test_joint").getIMotionCube().actuateRadFixedSpeed(0.6, 0.1);
+  march4.getJoint("test_joint").getIMotionCube().actuateRadFixedSpeed(1, 0.2);
+  march4.getJoint("test_joint").getIMotionCube().actuateRadFixedSpeed(0.6, 0.3);
 
   // Publish and print joint position
   //    ros::Publisher pub = nh.advertise<sensor_msgs::JointState>("march/joint_states", 5);
@@ -60,17 +63,17 @@ int main(int argc, char** argv)
   //    joint_state.position = {angleVal};
   //    pub.publish(joint_state);
 
-//   Print final status
-     sleep(1);
-     march4.getJoint("test_joint")
-         .getIMotionCube()
-         .parseStatusWord(march4.getJoint("test_joint").getIMotionCube().getStatusWord());
-     march4.getJoint("test_joint")
-         .getIMotionCube()
-         .parseMotionError(march4.getJoint("test_joint").getIMotionCube().getMotionError());
-     march4.getJoint("test_joint")
-         .getIMotionCube()
-         .parseDetailedError(march4.getJoint("test_joint").getIMotionCube().getDetailedError());
+  //   Print final status
+  sleep(1);
+  march4.getJoint("test_joint")
+      .getIMotionCube()
+      .parseStatusWord(march4.getJoint("test_joint").getIMotionCube().getStatusWord());
+  march4.getJoint("test_joint")
+      .getIMotionCube()
+      .parseMotionError(march4.getJoint("test_joint").getIMotionCube().getMotionError());
+  march4.getJoint("test_joint")
+      .getIMotionCube()
+      .parseDetailedError(march4.getJoint("test_joint").getIMotionCube().getDetailedError());
 
-     march4.stopEtherCAT();
+  march4.stopEtherCAT();
 }

--- a/march_hardware/test/TestJoint.cpp
+++ b/march_hardware/test/TestJoint.cpp
@@ -13,10 +13,38 @@ using ::testing::Return;
 using ::testing::AtLeast;
 using ::testing::AtMost;
 
-class TestJoint : public ::testing::Test
+class JointTest : public ::testing::Test
 {
 protected:
   const float temperature = 42;
 };
 
+class JointDeathTest : public ::testing::Test
+{
+protected:
+    const float temperature = 42;
+};
+
 // TODO(Tim) write joint tests (with mocking)
+
+TEST_F(JointTest, AllowActuation)
+{
+    march4cpp::TemperatureGES temp = march4cpp::TemperatureGES(2,2);
+    march4cpp::Joint joint = march4cpp::Joint("actuate_true", true, temp);
+    ASSERT_TRUE(joint.canActuate());
+}
+
+TEST_F(JointTest, DisableActuation)
+{
+    march4cpp::TemperatureGES temp = march4cpp::TemperatureGES(2,2);
+    march4cpp::Joint joint = march4cpp::Joint("actuate_false", false, temp);
+    ASSERT_FALSE(joint.canActuate());
+}
+
+TEST_F(JointDeathTest, ActuateDisableActuation)
+{
+    march4cpp::TemperatureGES temp = march4cpp::TemperatureGES(2,2);
+    march4cpp::Joint joint = march4cpp::Joint("actuate_false", false, temp);
+    ASSERT_FALSE(joint.canActuate());
+    ASSERT_DEATH(joint.actuateRad(0.3), "Joint actuate_false is not allowed to actuate, yet its actuate method has been called.");
+}

--- a/march_hardware_builder/include/march_hardware_builder/HardwareBuilder.h
+++ b/march_hardware_builder/include/march_hardware_builder/HardwareBuilder.h
@@ -23,7 +23,7 @@ private:
           { "resolution", "minPositionIU", "maxPositionIU", "zeroPositionIU", "safetyMarginRad" };
   const std::vector<std::string> IMOTIONCUBE_REQUIRED_KEYS = { "slaveIndex", "encoder" };
   const std::vector<std::string> TEMPERATUREGES_REQUIRED_KEYS = { "slaveIndex", "byteOffset" };
-  const std::vector<std::string> JOINT_REQUIRED_KEYS = {};
+  const std::vector<std::string> JOINT_REQUIRED_KEYS = {"actuate"};
 
   /**
    * @brief Loop over all keys in the keyList and check if they exist in the config. Throws a MissingKeyException when

--- a/march_hardware_builder/include/march_hardware_builder/HardwareBuilder.h
+++ b/march_hardware_builder/include/march_hardware_builder/HardwareBuilder.h
@@ -23,7 +23,7 @@ private:
           { "resolution", "minPositionIU", "maxPositionIU", "zeroPositionIU", "safetyMarginRad" };
   const std::vector<std::string> IMOTIONCUBE_REQUIRED_KEYS = { "slaveIndex", "encoder" };
   const std::vector<std::string> TEMPERATUREGES_REQUIRED_KEYS = { "slaveIndex", "byteOffset" };
-  const std::vector<std::string> JOINT_REQUIRED_KEYS = {"actuate"};
+  const std::vector<std::string> JOINT_REQUIRED_KEYS = {"allowActuation"};
 
   /**
    * @brief Loop over all keys in the keyList and check if they exist in the config. Throws a MissingKeyException when

--- a/march_hardware_builder/src/HardwareBuilder.cpp
+++ b/march_hardware_builder/src/HardwareBuilder.cpp
@@ -60,7 +60,7 @@ march4cpp::Joint HardwareBuilder::createJoint(YAML::Node jointConfig, std::strin
 
   bool hasIMotionCube = false;
   bool hasTemperatureGes = false;
-  bool actuate = jointConfig["actuate"].as<bool>();
+  bool allowActuation = jointConfig["allowActuation"].as<bool>();
 
 
   if (jointConfig["imotioncube"].Type() == YAML::NodeType::Undefined)
@@ -87,13 +87,13 @@ march4cpp::Joint HardwareBuilder::createJoint(YAML::Node jointConfig, std::strin
                  "Joint %s has no IMotionCube and no TemperatureGES. Please check its purpose.", jointName.c_str());
   if (hasTemperatureGes && hasIMotionCube)
   {
-    return march4cpp::Joint(jointName, actuate, temperatureGes, imc);
+    return march4cpp::Joint(jointName, allowActuation, temperatureGes, imc);
   }
   if (hasTemperatureGes)
   {
-    return march4cpp::Joint(jointName, actuate, temperatureGes);
+    return march4cpp::Joint(jointName, allowActuation, temperatureGes);
   }
-  return march4cpp::Joint(jointName, actuate, imc);
+  return march4cpp::Joint(jointName, allowActuation, imc);
 }
 
 march4cpp::IMotionCube HardwareBuilder::createIMotionCube(YAML::Node iMotionCubeConfig)

--- a/march_hardware_builder/src/HardwareBuilder.cpp
+++ b/march_hardware_builder/src/HardwareBuilder.cpp
@@ -52,13 +52,16 @@ march4cpp::MarchRobot HardwareBuilder::createMarchRobot()
 march4cpp::Joint HardwareBuilder::createJoint(YAML::Node jointConfig, std::string jointName)
 {
   ROS_INFO("Starting creation of joint %s", jointName.c_str());
+  this->validateRequiredKeysExist(jointConfig, this->JOINT_REQUIRED_KEYS, "joint");
+
 
   march4cpp::IMotionCube imc;
   march4cpp::TemperatureGES temperatureGes;
 
   bool hasIMotionCube = false;
   bool hasTemperatureGes = false;
-  this->validateRequiredKeysExist(jointConfig, this->JOINT_REQUIRED_KEYS, "joint");
+  bool actuate = jointConfig["actuate"].as<bool>();
+
 
   if (jointConfig["imotioncube"].Type() == YAML::NodeType::Undefined)
   {
@@ -84,13 +87,13 @@ march4cpp::Joint HardwareBuilder::createJoint(YAML::Node jointConfig, std::strin
                  "Joint %s has no IMotionCube and no TemperatureGES. Please check its purpose.", jointName.c_str());
   if (hasTemperatureGes && hasIMotionCube)
   {
-    return march4cpp::Joint(jointName, temperatureGes, imc);
+    return march4cpp::Joint(jointName, actuate, temperatureGes, imc);
   }
   if (hasTemperatureGes)
   {
-    return march4cpp::Joint(jointName, temperatureGes);
+    return march4cpp::Joint(jointName, actuate, temperatureGes);
   }
-  return march4cpp::Joint(jointName, imc);
+  return march4cpp::Joint(jointName, actuate, imc);
 }
 
 march4cpp::IMotionCube HardwareBuilder::createIMotionCube(YAML::Node iMotionCubeConfig)

--- a/march_hardware_builder/src/robots/march3.yaml
+++ b/march_hardware_builder/src/robots/march3.yaml
@@ -3,6 +3,7 @@ march3:
   ecatCycleTime: 4
   joints:
     - right_hip:
+        actuate: true
         imotioncube:
           slaveIndex: 8
           encoder:
@@ -12,6 +13,7 @@ march3:
             zeroPositionIU: 24515
             safetyMarginRad: 0.05
     - left_hip:
+        actuate: true
         imotioncube:
           slaveIndex: 3
           encoder:
@@ -21,6 +23,7 @@ march3:
             zeroPositionIU: 11830
             safetyMarginRad: 0.05
     - right_knee:
+        actuate: true
         imotioncube:
           slaveIndex: 10
           encoder:
@@ -30,6 +33,7 @@ march3:
             zeroPositionIU: 19000
             safetyMarginRad: 0.05
     - left_knee:
+        actuate: true
         imotioncube:
           slaveIndex: 5
           encoder:
@@ -39,6 +43,7 @@ march3:
             zeroPositionIU: 22552
             safetyMarginRad: 0.05
     - right_ankle:
+        actuate: true
         imotioncube:
           slaveIndex: 12
           encoder:
@@ -48,6 +53,7 @@ march3:
             zeroPositionIU: 1301
             safetyMarginRad: 0.005
     - left_ankle:
+        actuate: true
         imotioncube:
           slaveIndex: 7
           encoder:

--- a/march_hardware_builder/src/robots/march3.yaml
+++ b/march_hardware_builder/src/robots/march3.yaml
@@ -3,7 +3,7 @@ march3:
   ecatCycleTime: 4
   joints:
     - right_hip:
-        actuate: true
+        allowActuation: true
         imotioncube:
           slaveIndex: 8
           encoder:
@@ -13,7 +13,7 @@ march3:
             zeroPositionIU: 24515
             safetyMarginRad: 0.05
     - left_hip:
-        actuate: true
+        allowActuation: true
         imotioncube:
           slaveIndex: 3
           encoder:
@@ -23,7 +23,7 @@ march3:
             zeroPositionIU: 11830
             safetyMarginRad: 0.05
     - right_knee:
-        actuate: true
+        allowActuation: true
         imotioncube:
           slaveIndex: 10
           encoder:
@@ -33,7 +33,7 @@ march3:
             zeroPositionIU: 19000
             safetyMarginRad: 0.05
     - left_knee:
-        actuate: true
+        allowActuation: true
         imotioncube:
           slaveIndex: 5
           encoder:
@@ -43,7 +43,7 @@ march3:
             zeroPositionIU: 22552
             safetyMarginRad: 0.05
     - right_ankle:
-        actuate: true
+        allowActuation: true
         imotioncube:
           slaveIndex: 12
           encoder:
@@ -53,7 +53,7 @@ march3:
             zeroPositionIU: 1301
             safetyMarginRad: 0.005
     - left_ankle:
-        actuate: true
+        allowActuation: true
         imotioncube:
           slaveIndex: 7
           encoder:

--- a/march_hardware_builder/src/robots/testsetup.yaml
+++ b/march_hardware_builder/src/robots/testsetup.yaml
@@ -3,7 +3,7 @@ testsetup:
   ecatCycleTime: 4
   joints:
     - test_joint:
-        actuate: true
+        allowActuation: true
         temperatureges:
           slaveIndex: 1
           byteOffset: 0

--- a/march_hardware_builder/src/robots/testsetup.yaml
+++ b/march_hardware_builder/src/robots/testsetup.yaml
@@ -3,6 +3,7 @@ testsetup:
   ecatCycleTime: 4
   joints:
     - test_joint:
+        actuate: true
         temperatureges:
           slaveIndex: 1
           byteOffset: 0

--- a/march_hardware_builder/test/TestAllowedRobots.cpp
+++ b/march_hardware_builder/test/TestAllowedRobots.cpp
@@ -41,12 +41,12 @@ TEST_F(AllowedRobotTest, TestMarch3Values)
   march4cpp::IMotionCube RKJimc = march4cpp::IMotionCube(10, RKJenc);
   march4cpp::IMotionCube RAJimc = march4cpp::IMotionCube(12, RAJenc);
 
-  march4cpp::Joint leftHip = march4cpp::Joint("left_hip", LHJimc);
-  march4cpp::Joint leftKnee = march4cpp::Joint("left_knee", LKJimc);
-  march4cpp::Joint leftAnkle = march4cpp::Joint("left_ankle", LAJimc);
-  march4cpp::Joint rightHip = march4cpp::Joint("right_hip", RHJimc);
-  march4cpp::Joint rightKnee = march4cpp::Joint("right_knee", RKJimc);
-  march4cpp::Joint rightAnkle = march4cpp::Joint("right_ankle", RAJimc);
+  march4cpp::Joint leftHip = march4cpp::Joint("left_hip", true, LHJimc);
+  march4cpp::Joint leftKnee = march4cpp::Joint("left_knee", true, LKJimc);
+  march4cpp::Joint leftAnkle = march4cpp::Joint("left_ankle", true, LAJimc);
+  march4cpp::Joint rightHip = march4cpp::Joint("right_hip", true, RHJimc);
+  march4cpp::Joint rightKnee = march4cpp::Joint("right_knee", true, RKJimc);
+  march4cpp::Joint rightAnkle = march4cpp::Joint("right_ankle", true, RAJimc);
 
   std::vector<march4cpp::Joint> jointList;
   jointList.push_back(rightHip);

--- a/march_hardware_builder/test/TestHardwareBuilderCreateJoint.cpp
+++ b/march_hardware_builder/test/TestHardwareBuilderCreateJoint.cpp
@@ -41,9 +41,26 @@ TEST_F(JointTest, ValidJointHip)
   march4cpp::Encoder actualEncoder = march4cpp::Encoder(16, 22134, 43436, 24515, 0.05);
   march4cpp::IMotionCube actualIMotionCube = march4cpp::IMotionCube(2, actualEncoder);
   march4cpp::TemperatureGES actualTemperatureGes = march4cpp::TemperatureGES(1, 2);
-  march4cpp::Joint actualJoint = march4cpp::Joint("test_joint_hip", actualTemperatureGes, actualIMotionCube);
+  march4cpp::Joint actualJoint = march4cpp::Joint("test_joint_hip", true, actualTemperatureGes, actualIMotionCube);
 
   ASSERT_EQ("test_joint_hip", actualJoint.getName());
+  ASSERT_EQ(actualJoint, createdJoint);
+}
+
+TEST_F(JointTest, ValidNotActuated)
+{
+  std::string fullPath = this->fullPath("/joint_correct_not_actuated.yaml");
+  YAML::Node jointConfig = YAML::LoadFile(fullPath);
+
+  march4cpp::Joint createdJoint = hardwareBuilder.createJoint(jointConfig, "test_joint_hip");
+
+  march4cpp::Encoder actualEncoder = march4cpp::Encoder(16, 22134, 43436, 24515, 0.05);
+  march4cpp::IMotionCube actualIMotionCube = march4cpp::IMotionCube(2, actualEncoder);
+  march4cpp::TemperatureGES actualTemperatureGes = march4cpp::TemperatureGES(1, 2);
+  march4cpp::Joint actualJoint = march4cpp::Joint("test_joint_hip", false, actualTemperatureGes, actualIMotionCube);
+
+  ASSERT_EQ("test_joint_hip", actualJoint.getName());
+  ASSERT_FALSE(actualJoint.canActuate());
   ASSERT_EQ(actualJoint, createdJoint);
 }
 
@@ -58,9 +75,17 @@ TEST_F(JointTest, ValidJointAnkle)
   march4cpp::IMotionCube actualIMotionCube = march4cpp::IMotionCube(10, actualEncoder);
   march4cpp::TemperatureGES actualTemperatureGes = march4cpp::TemperatureGES(10, 6);
 
-  march4cpp::Joint actualJoint = march4cpp::Joint("test_joint_ankle", actualTemperatureGes, actualIMotionCube);
+  march4cpp::Joint actualJoint = march4cpp::Joint("test_joint_ankle", true, actualTemperatureGes, actualIMotionCube);
   ASSERT_EQ("test_joint_ankle", actualJoint.getName());
   ASSERT_EQ(actualJoint, createdJoint);
+}
+
+TEST_F(JointTest, NoActuate)
+{
+  std::string fullPath = this->fullPath("/joint_no_actuate.yaml");
+  YAML::Node jointConfig = YAML::LoadFile(fullPath);
+
+  ASSERT_THROW(hardwareBuilder.createJoint(jointConfig, "test_joint_no_actuate"), MissingKeyException);
 }
 
 TEST_F(JointTest, NoIMotionCube)

--- a/march_hardware_builder/test/TestHardwareBuilderCreateJoint.cpp
+++ b/march_hardware_builder/test/TestHardwareBuilderCreateJoint.cpp
@@ -58,10 +58,12 @@ TEST_F(JointTest, ValidNotActuated)
   march4cpp::IMotionCube actualIMotionCube = march4cpp::IMotionCube(2, actualEncoder);
   march4cpp::TemperatureGES actualTemperatureGes = march4cpp::TemperatureGES(1, 2);
   march4cpp::Joint actualJoint = march4cpp::Joint("test_joint_hip", false, actualTemperatureGes, actualIMotionCube);
+  march4cpp::Joint actualJointWrong = march4cpp::Joint("test_joint_hip", true, actualTemperatureGes, actualIMotionCube);
 
   ASSERT_EQ("test_joint_hip", actualJoint.getName());
   ASSERT_FALSE(actualJoint.canActuate());
   ASSERT_EQ(actualJoint, createdJoint);
+  ASSERT_NE(actualJointWrong, createdJoint);
 }
 
 TEST_F(JointTest, ValidJointAnkle)
@@ -104,11 +106,19 @@ TEST_F(JointTest, NoTemperatureGES)
   ASSERT_NO_THROW(hardwareBuilder.createJoint(jointConfig, "test_joint_no_temperature_ges"));
 }
 
+TEST_F(JointDeathTest, OnlyActuate)
+{
+  std::string fullPath = this->fullPath("/joint_only_actuate.yaml");
+  YAML::Node jointConfig = YAML::LoadFile(fullPath);
+
+  ASSERT_DEATH(hardwareBuilder.createJoint(jointConfig, "test_joint_only_actuate"),
+               "Joint test_joint_only_actuate has no IMotionCube and no TemperatureGES. Please check its purpose.");
+}
+
 TEST_F(JointDeathTest, EmptyJoint)
 {
   std::string fullPath = this->fullPath("/joint_empty.yaml");
   YAML::Node jointConfig = YAML::LoadFile(fullPath);
 
-  ASSERT_DEATH(hardwareBuilder.createJoint(jointConfig, "test_joint_empty_joint"),
-               "Joint test_joint_empty_joint has no IMotionCube and no TemperatureGES. Please check its purpose.");
+  ASSERT_THROW(hardwareBuilder.createJoint(jointConfig, "test_joint_empty"), MissingKeyException);
 }

--- a/march_hardware_builder/test/yaml/joint/joint_correct_1.yaml
+++ b/march_hardware_builder/test/yaml/joint/joint_correct_1.yaml
@@ -1,4 +1,4 @@
-actuate: true
+allowActuation: true
 imotioncube:
   slaveIndex: 2
   encoder:

--- a/march_hardware_builder/test/yaml/joint/joint_correct_2.yaml
+++ b/march_hardware_builder/test/yaml/joint/joint_correct_2.yaml
@@ -1,4 +1,4 @@
-actuate: true
+allowActuation: true
 imotioncube:
   slaveIndex: 10
   encoder:

--- a/march_hardware_builder/test/yaml/joint/joint_correct_2.yaml
+++ b/march_hardware_builder/test/yaml/joint/joint_correct_2.yaml
@@ -1,3 +1,4 @@
+actuate: true
 imotioncube:
   slaveIndex: 10
   encoder:

--- a/march_hardware_builder/test/yaml/joint/joint_correct_no_actuate.yaml
+++ b/march_hardware_builder/test/yaml/joint/joint_correct_no_actuate.yaml
@@ -1,4 +1,4 @@
-actuate: true
+actuate: false
 imotioncube:
   slaveIndex: 2
   encoder:

--- a/march_hardware_builder/test/yaml/joint/joint_correct_not_actuated.yaml
+++ b/march_hardware_builder/test/yaml/joint/joint_correct_not_actuated.yaml
@@ -1,4 +1,4 @@
-actuate: false
+allowActuation: false
 imotioncube:
   slaveIndex: 2
   encoder:

--- a/march_hardware_builder/test/yaml/joint/joint_correct_not_actuated.yaml
+++ b/march_hardware_builder/test/yaml/joint/joint_correct_not_actuated.yaml
@@ -1,4 +1,4 @@
-actuate: true
+actuate: false
 imotioncube:
   slaveIndex: 2
   encoder:

--- a/march_hardware_builder/test/yaml/joint/joint_no_actuate.yaml
+++ b/march_hardware_builder/test/yaml/joint/joint_no_actuate.yaml
@@ -1,4 +1,3 @@
-actuate: false
 imotioncube:
   slaveIndex: 2
   encoder:

--- a/march_hardware_builder/test/yaml/joint/joint_no_imotioncube.yaml
+++ b/march_hardware_builder/test/yaml/joint/joint_no_imotioncube.yaml
@@ -1,3 +1,4 @@
+actuate: true
 temperatureges:
   slaveIndex: 1
   byteOffset: 2

--- a/march_hardware_builder/test/yaml/joint/joint_no_imotioncube.yaml
+++ b/march_hardware_builder/test/yaml/joint/joint_no_imotioncube.yaml
@@ -1,4 +1,4 @@
-actuate: true
+allowActuation: true
 temperatureges:
   slaveIndex: 1
   byteOffset: 2

--- a/march_hardware_builder/test/yaml/joint/joint_no_temperature_ges.yaml
+++ b/march_hardware_builder/test/yaml/joint/joint_no_temperature_ges.yaml
@@ -1,4 +1,4 @@
-actuate: true
+allowActuation: true
 imotioncube:
   slaveIndex: 10
   encoder:

--- a/march_hardware_builder/test/yaml/joint/joint_no_temperature_ges.yaml
+++ b/march_hardware_builder/test/yaml/joint/joint_no_temperature_ges.yaml
@@ -1,3 +1,4 @@
+actuate: true
 imotioncube:
   slaveIndex: 10
   encoder:

--- a/march_hardware_builder/test/yaml/joint/joint_only_actuate.yaml
+++ b/march_hardware_builder/test/yaml/joint/joint_only_actuate.yaml
@@ -1,1 +1,1 @@
-actuate: false
+allowActuation: false

--- a/march_hardware_builder/test/yaml/joint/joint_only_actuate.yaml
+++ b/march_hardware_builder/test/yaml/joint/joint_only_actuate.yaml
@@ -1,0 +1,1 @@
+actuate: false

--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -102,7 +102,10 @@ void MarchHardwareInterface::init()
     effort_joint_interface_.registerHandle(jointEffortHandle);
 
     // Enable high voltage on the IMC
-    joint.getIMotionCube().goToOperationEnabled();
+    if (joint.canActuate())
+    {
+      joint.getIMotionCube().goToOperationEnabled();
+    }
   }
 
   registerInterface(&joint_state_interface_);
@@ -134,9 +137,12 @@ void MarchHardwareInterface::write(ros::Duration elapsed_time)
 
   for (int i = 0; i < num_joints_; i++)
   {
-    ROS_DEBUG("After limits: Trying to actuate joint %s, to %lf rad, %f speed, %f effort.", joint_names_[i].c_str(),
-              joint_position_command_[i], joint_velocity_command_[i], joint_effort_command_[i]);
-    marchRobot.getJoint(joint_names_[i]).actuateRad(static_cast<float>(joint_position_command_[i]));
+    if (marchRobot.getJoint(joint_names_[i]).canActuate())
+    {
+      ROS_DEBUG("After limits: Trying to actuate joint %s, to %lf rad, %f speed, %f effort.", joint_names_[i].c_str(),
+                joint_position_command_[i], joint_velocity_command_[i], joint_effort_command_[i]);
+      marchRobot.getJoint(joint_names_[i]).actuateRad(static_cast<float>(joint_position_command_[i]));
+    }
   }
 }
 }  // namespace march_hardware_interface


### PR DESCRIPTION
It is now possible to toggle whether a joint should be actuated or not from the `.yaml` file.
This will make it much easier to calibrate the encoders and create passive joints.

It is no longer required to comment and recompile the `imc.goToOperationEnabled()` function :)

I have updated the old tests and included some new ones to properly test this behaviour.