### PR TITLE
Actual temperature sensor support

### DIFF
--- a/march_hardware/include/march_hardware/TemperatureGES.h
+++ b/march_hardware/include/march_hardware/TemperatureGES.h
@@ -11,14 +11,14 @@ namespace march4cpp
 class TemperatureGES : public Slave, TemperatureSensor
 {
 private:
-  int byteOffset;
+  int temperatureByteOffset;
 
 public:
-  TemperatureGES(int slaveIndex, int byteOffset);
+  TemperatureGES(int slaveIndex, int temperatureByteOffset);
 
   TemperatureGES()
   {
-    byteOffset = -1;
+    temperatureByteOffset = -1;
     slaveIndex = -1;
   };
 
@@ -27,13 +27,13 @@ public:
   /** @brief Override comparison operator */
   friend bool operator==(const TemperatureGES& lhs, const TemperatureGES& rhs)
   {
-    return lhs.slaveIndex == rhs.slaveIndex && lhs.byteOffset == rhs.byteOffset;
+    return lhs.slaveIndex == rhs.slaveIndex && lhs.temperatureByteOffset == rhs.temperatureByteOffset;
   }
   /** @brief Override stream operator for clean printing */
   friend ::std::ostream& operator<<(std::ostream& os, const TemperatureGES& temperatureGes)
   {
     return os << "slaveIndex: " << temperatureGes.slaveIndex << ", "
-              << "byteOffset: " << temperatureGes.byteOffset;
+              << "byteOffset: " << temperatureGes.temperatureByteOffset;
   }
 };
 }  // namespace march4cpp

--- a/march_hardware/include/march_hardware/TemperatureGES.h
+++ b/march_hardware/include/march_hardware/TemperatureGES.h
@@ -33,7 +33,7 @@ public:
   friend ::std::ostream& operator<<(std::ostream& os, const TemperatureGES& temperatureGes)
   {
     return os << "slaveIndex: " << temperatureGes.slaveIndex << ", "
-              << "byteOffset: " << temperatureGes.temperatureByteOffset;
+              << "temperatureByteOffset: " << temperatureGes.temperatureByteOffset;
   }
 };
 }  // namespace march4cpp

--- a/march_hardware/src/TemperatureGES.cpp
+++ b/march_hardware/src/TemperatureGES.cpp
@@ -5,17 +5,18 @@
 
 namespace march4cpp
 {
-TemperatureGES::TemperatureGES(int slaveIndex, int byteOffset) : Slave(slaveIndex)
+TemperatureGES::TemperatureGES(int slaveIndex, int temperatureByteOffset) : Slave(slaveIndex)
 {
-  ROS_ASSERT_MSG(byteOffset >= 0, "Slave configuration error: byteOffset %d can not be negative.", byteOffset);
-  this->byteOffset = byteOffset;
+  ROS_ASSERT_MSG(temperatureByteOffset >= 0, "Slave configuration error: temperatureByteOffset %d can not be negative.",
+                 temperatureByteOffset);
+  this->temperatureByteOffset = temperatureByteOffset;
 }
 
 float TemperatureGES::getTemperature()
 {
-  // TODO(Martijn) read actual data from ethercat.
-  union bit8 return_byte = get_input_bit8(static_cast<uint16>(slaveIndex), static_cast<uint8>(byteOffset));
-  return static_cast<float>(return_byte.ui);
+  union bit32 temperature =
+      get_input_bit32(static_cast<uint16>(slaveIndex), static_cast<uint8>(this->temperatureByteOffset));
+  return temperature.f;
 }
 
 }  // namespace march4cpp

--- a/march_hardware/src/main.cpp
+++ b/march_hardware/src/main.cpp
@@ -18,40 +18,41 @@
 
 int main(int argc, char** argv)
 {
-    march4cpp::TemperatureGES temperatureGES = march4cpp::TemperatureGES(1, 0);
-//     TODO(ISHA, MARTIJN) double-check these numbers.
-//    march4cpp::Encoder enc = march4cpp::Encoder(16, 37961, 59649, 39717, 0.05);
-//    march4cpp::IMotionCube imc = march4cpp::IMotionCube(2, enc);
-    march4cpp::Joint temp = march4cpp::Joint("test_joint", temperatureGES);
+  march4cpp::TemperatureGES temperatureGES = march4cpp::TemperatureGES(1, 0);
+  // TODO(ISHA, MARTIJN) double-check these numbers.
+  // march4cpp::Encoder enc = march4cpp::Encoder(16, 37961, 59649, 39717, 0.05);
+  // march4cpp::IMotionCube imc = march4cpp::IMotionCube(2, enc);
+  march4cpp::Joint temp = march4cpp::Joint("test_joint", temperatureGES);
 
-    std::vector<march4cpp::Joint> jointList;
-    jointList.push_back(temp);
+  std::vector<march4cpp::Joint> jointList;
+  jointList.push_back(temp);
 
-    int ecatCycleTime = 4;  // milliseconds
-    march4cpp::MarchRobot march4 = march4cpp::MarchRobot(jointList, "enp2s0", ecatCycleTime);
-    march4.startEtherCAT();
+  int ecatCycleTime = 4;  // milliseconds
+  march4cpp::MarchRobot march4 = march4cpp::MarchRobot(jointList, "enp2s0", ecatCycleTime);
+  march4.startEtherCAT();
 
-     if (!march4.isEthercatOperational())
-     {
-       ROS_FATAL("EtherCAT is not operational");
-       return 0;
-     }
+  if (!march4.isEthercatOperational())
+  {
+    ROS_FATAL("EtherCAT is not operational");
+    return 0;
+  }
 
-//     ros::init(argc, argv, "dummy");
-//     ros::NodeHandle nh;
-//     ros::Rate rate(10);
+  //     ros::init(argc, argv, "dummy");
+  //     ros::NodeHandle nh;
+  //     ros::Rate rate(10);
 
-     // Uncomment to allow actuation.
-//     march4.getJoint("test_joint").getIMotionCube().goToOperationEnabled();
-     ROS_INFO("march4 initialized");
-     while(1){
-         ROS_INFO("Temperature: %f", march4.getJoint("test_joint").getTemperature());
-     }
+  // Uncomment to allow actuation.
+  //     march4.getJoint("test_joint").getIMotionCube().goToOperationEnabled();
+  ROS_INFO("march4 initialized");
+  while (1)
+  {
+    ROS_INFO("Temperature: %f", march4.getJoint("test_joint").getTemperature());
+  }
 
-//     ROS_INFO_STREAM("Angle: " << march4.getJoint("test_joint").getAngleRad());
-//     march4.getJoint("test_joint").getIMotionCube().actuateRadFixedSpeed(0.6, 0.1);
-//     march4.getJoint("test_joint").getIMotionCube().actuateRadFixedSpeed(1, 0.2);
-//     march4.getJoint("test_joint").getIMotionCube().actuateRadFixedSpeed(0.6, 0.3);
+  //     ROS_INFO_STREAM("Angle: " << march4.getJoint("test_joint").getAngleRad());
+  //     march4.getJoint("test_joint").getIMotionCube().actuateRadFixedSpeed(0.6, 0.1);
+  //     march4.getJoint("test_joint").getIMotionCube().actuateRadFixedSpeed(1, 0.2);
+  //     march4.getJoint("test_joint").getIMotionCube().actuateRadFixedSpeed(0.6, 0.3);
 
   // Publish and print joint position
   //    ros::Publisher pub = nh.advertise<sensor_msgs::JointState>("march/joint_states", 5);
@@ -63,17 +64,17 @@ int main(int argc, char** argv)
   //    joint_state.position = {angleVal};
   //    pub.publish(joint_state);
 
-//   Print final status
-//     sleep(1);
-//     march4.getJoint("test_joint")
-//         .getIMotionCube()
-//         .parseStatusWord(march4.getJoint("test_joint").getIMotionCube().getStatusWord());
-//     march4.getJoint("test_joint")
-//         .getIMotionCube()
-//         .parseMotionError(march4.getJoint("test_joint").getIMotionCube().getMotionError());
-//     march4.getJoint("test_joint")
-//         .getIMotionCube()
-//         .parseDetailedError(march4.getJoint("test_joint").getIMotionCube().getDetailedError());
+  //   Print final status
+  //     sleep(1);
+  //     march4.getJoint("test_joint")
+  //         .getIMotionCube()
+  //         .parseStatusWord(march4.getJoint("test_joint").getIMotionCube().getStatusWord());
+  //     march4.getJoint("test_joint")
+  //         .getIMotionCube()
+  //         .parseMotionError(march4.getJoint("test_joint").getIMotionCube().getMotionError());
+  //     march4.getJoint("test_joint")
+  //         .getIMotionCube()
+  //         .parseDetailedError(march4.getJoint("test_joint").getIMotionCube().getDetailedError());
 
-     march4.stopEtherCAT();
+  march4.stopEtherCAT();
 }

--- a/march_hardware/src/main.cpp
+++ b/march_hardware/src/main.cpp
@@ -19,16 +19,16 @@
 int main(int argc, char** argv)
 {
     march4cpp::TemperatureGES temperatureGES = march4cpp::TemperatureGES(1, 0);
-    // TODO(ISHA, MARTIJN) double-check these numbers.
-    march4cpp::Encoder enc = march4cpp::Encoder(16, 37961, 59649, 39717, 0.05);
-    march4cpp::IMotionCube imc = march4cpp::IMotionCube(2, enc);
-    march4cpp::Joint temp = march4cpp::Joint("test_joint", temperatureGES, imc);
+//     TODO(ISHA, MARTIJN) double-check these numbers.
+//    march4cpp::Encoder enc = march4cpp::Encoder(16, 37961, 59649, 39717, 0.05);
+//    march4cpp::IMotionCube imc = march4cpp::IMotionCube(2, enc);
+    march4cpp::Joint temp = march4cpp::Joint("test_joint", temperatureGES);
 
     std::vector<march4cpp::Joint> jointList;
     jointList.push_back(temp);
 
     int ecatCycleTime = 4;  // milliseconds
-    march4cpp::MarchRobot march4 = march4cpp::MarchRobot(jointList, "enp2s0", ecatCycleTime);
+    march4cpp::MarchRobot march4 = march4cpp::MarchRobot(jointList, "enp4s0f2", ecatCycleTime);
     march4.startEtherCAT();
 
      if (!march4.isEthercatOperational())
@@ -37,18 +37,21 @@ int main(int argc, char** argv)
        return 0;
      }
 
-     ros::init(argc, argv, "dummy");
-     ros::NodeHandle nh;
-     ros::Rate rate(10);
+//     ros::init(argc, argv, "dummy");
+//     ros::NodeHandle nh;
+//     ros::Rate rate(10);
 
      // Uncomment to allow actuation.
-     march4.getJoint("test_joint").getIMotionCube().goToOperationEnabled();
+//     march4.getJoint("test_joint").getIMotionCube().goToOperationEnabled();
      ROS_INFO("march4 initialized");
+     while(1){
+         ROS_INFO("Temperature: %f", march4.getJoint("test_joint").getTemperature());
+     }
 
-     ROS_INFO_STREAM("Angle: " << march4.getJoint("test_joint").getAngleRad());
-     march4.getJoint("test_joint").getIMotionCube().actuateRadFixedSpeed(0.6, 0.1);
-     march4.getJoint("test_joint").getIMotionCube().actuateRadFixedSpeed(1, 0.2);
-     march4.getJoint("test_joint").getIMotionCube().actuateRadFixedSpeed(0.6, 0.3);
+//     ROS_INFO_STREAM("Angle: " << march4.getJoint("test_joint").getAngleRad());
+//     march4.getJoint("test_joint").getIMotionCube().actuateRadFixedSpeed(0.6, 0.1);
+//     march4.getJoint("test_joint").getIMotionCube().actuateRadFixedSpeed(1, 0.2);
+//     march4.getJoint("test_joint").getIMotionCube().actuateRadFixedSpeed(0.6, 0.3);
 
   // Publish and print joint position
   //    ros::Publisher pub = nh.advertise<sensor_msgs::JointState>("march/joint_states", 5);
@@ -61,16 +64,16 @@ int main(int argc, char** argv)
   //    pub.publish(joint_state);
 
 //   Print final status
-     sleep(1);
-     march4.getJoint("test_joint")
-         .getIMotionCube()
-         .parseStatusWord(march4.getJoint("test_joint").getIMotionCube().getStatusWord());
-     march4.getJoint("test_joint")
-         .getIMotionCube()
-         .parseMotionError(march4.getJoint("test_joint").getIMotionCube().getMotionError());
-     march4.getJoint("test_joint")
-         .getIMotionCube()
-         .parseDetailedError(march4.getJoint("test_joint").getIMotionCube().getDetailedError());
+//     sleep(1);
+//     march4.getJoint("test_joint")
+//         .getIMotionCube()
+//         .parseStatusWord(march4.getJoint("test_joint").getIMotionCube().getStatusWord());
+//     march4.getJoint("test_joint")
+//         .getIMotionCube()
+//         .parseMotionError(march4.getJoint("test_joint").getIMotionCube().getMotionError());
+//     march4.getJoint("test_joint")
+//         .getIMotionCube()
+//         .parseDetailedError(march4.getJoint("test_joint").getIMotionCube().getDetailedError());
 
      march4.stopEtherCAT();
 }

--- a/march_hardware/src/main.cpp
+++ b/march_hardware/src/main.cpp
@@ -41,12 +41,13 @@ int main(int argc, char** argv)
   //     ros::NodeHandle nh;
   //     ros::Rate rate(10);
 
-  if (march4.getJoint("test_joint").canActuate()) {
-      //     march4.getJoint("test_joint").getIMotionCube().goToOperationEnabled();}
-      ROS_INFO("march4 initialized");
-      while (1) {
-          ROS_INFO("Temperature: %f", march4.getJoint("test_joint").getTemperature());
-      }
+  if (march4.getJoint("test_joint").canActuate())
+  {
+    //     march4.getJoint("test_joint").getIMotionCube().goToOperationEnabled();}
+    ROS_INFO("march4 initialized");
+    while (1)
+    {
+      ROS_INFO("Temperature: %f", march4.getJoint("test_joint").getTemperature());
+    }
   }
-
 }

--- a/march_hardware/src/main.cpp
+++ b/march_hardware/src/main.cpp
@@ -28,7 +28,7 @@ int main(int argc, char** argv)
     jointList.push_back(temp);
 
     int ecatCycleTime = 4;  // milliseconds
-    march4cpp::MarchRobot march4 = march4cpp::MarchRobot(jointList, "enp4s0f2", ecatCycleTime);
+    march4cpp::MarchRobot march4 = march4cpp::MarchRobot(jointList, "enp2s0", ecatCycleTime);
     march4.startEtherCAT();
 
      if (!march4.isEthercatOperational())

--- a/march_hardware/test/TestTemperatureGES.cpp
+++ b/march_hardware/test/TestTemperatureGES.cpp
@@ -40,7 +40,7 @@ TEST_F(TemperatureJointTest, ByteOffsetZero)
 
 TEST_F(TemperatureJointDeathTest, ByteOffsetMinusOne)
 {
-    ASSERT_DEATH(march4cpp::TemperatureGES(2, -1), "Slave configuration error: byteOffset -1 can not be negative.");
+    ASSERT_DEATH(march4cpp::TemperatureGES(2, -1), "Slave configuration error: temperatureByteOffset -1 can not be negative.");
 }
 
 TEST_F(TemperatureJointTest, NoSlaveIndexConstructor)


### PR DESCRIPTION
refactors byteOffset to temperatureByteOffset in temperatureGES class.
returns actual temperature when used with for example temperature_template_ges
(requires byteOffset 0 in hardwareBuilder)

This code was tested succesfully with a GES running this software: 
https://github.com/project-march/ethercat-slaves/pull/25
using this library:
https://github.com/project-march/slave-peripherals/pull/6