### PR TITLE
Remove getImotionCube() method from Joint to hide hardware implementation

### DIFF
--- a/march_hardware/include/march_hardware/Joint.h
+++ b/march_hardware/include/march_hardware/Joint.h
@@ -23,6 +23,8 @@ public:
   Joint(std::string name, bool allowActuation, IMotionCube iMotionCube);
 
   void initialize(int ecatCycleTime);
+  void prepareActuation();
+
   void actuateRad(float targetPositionRad);
 
   float getAngleRad();
@@ -31,7 +33,6 @@ public:
   std::string getName();
   int getTemperatureGESSlaveIndex();
   int getIMotionCubeSlaveIndex();
-  IMotionCube getIMotionCube();
 
   bool hasIMotionCube();
   bool hasTemperatureGES();

--- a/march_hardware/src/Joint.cpp
+++ b/march_hardware/src/Joint.cpp
@@ -36,11 +36,19 @@ void Joint::initialize(int ecatCycleTime)
   }
 }
 
+void Joint::prepareActuation()
+{
+  if (this->allowActuation)
+  {
+    this->iMotionCube.goToOperationEnabled();
+  }
+}
+
 void Joint::actuateRad(float targetPositionRad)
 {
   ROS_ASSERT_MSG(this->allowActuation, "Joint %s is not allowed to actuate, yet its actuate method has been called.",
-          this->name.c_str());
-    // TODO(BaCo) check that the position is allowed and does not exceed (torque) limits.
+                 this->name.c_str());
+  // TODO(BaCo) check that the position is allowed and does not exceed (torque) limits.
   this->iMotionCube.actuateRad(targetPositionRad);
 }
 
@@ -80,11 +88,6 @@ int Joint::getIMotionCubeSlaveIndex()
     return this->iMotionCube.getSlaveIndex();
   }
   return -1;
-}
-
-IMotionCube Joint::getIMotionCube()
-{
-  return this->iMotionCube;
 }
 
 std::string Joint::getName()

--- a/march_hardware/src/Joint.cpp
+++ b/march_hardware/src/Joint.cpp
@@ -42,6 +42,10 @@ void Joint::prepareActuation()
   {
     this->iMotionCube.goToOperationEnabled();
   }
+  else
+  {
+    ROS_ERROR("Trying to prepare joint %s for actuation while it is not allowed to actuate", this->name.c_str());
+  }
 }
 
 void Joint::actuateRad(float targetPositionRad)

--- a/march_hardware/src/main.cpp
+++ b/march_hardware/src/main.cpp
@@ -43,37 +43,12 @@ int main(int argc, char** argv)
 
   if (march4.getJoint("test_joint").canActuate())
   {
-    march4.getJoint("test_joint").getIMotionCube().goToOperationEnabled();
+    march4.getJoint("test_joint").prepareActuation();
   }
 
   ROS_INFO("march4 initialized");
 
   ROS_INFO_STREAM("Angle: " << march4.getJoint("test_joint").getAngleRad());
-  march4.getJoint("test_joint").getIMotionCube().actuateRadFixedSpeed(0.6, 0.1);
-  march4.getJoint("test_joint").getIMotionCube().actuateRadFixedSpeed(1, 0.2);
-  march4.getJoint("test_joint").getIMotionCube().actuateRadFixedSpeed(0.6, 0.3);
-
-  // Publish and print joint position
-  //    ros::Publisher pub = nh.advertise<sensor_msgs::JointState>("march/joint_states", 5);
-  //    angleVal = march4.getJoint("test_joint").getAngleRad();
-  //    printf("imc get: %f\n", angleVal);
-  //    sensor_msgs::JointState joint_state;
-  //    joint_state.header.stamp = ros::Time::now();
-  //    joint_state.name = {"test_joint"};
-  //    joint_state.position = {angleVal};
-  //    pub.publish(joint_state);
-
-  //   Print final status
-  sleep(1);
-  march4.getJoint("test_joint")
-      .getIMotionCube()
-      .parseStatusWord(march4.getJoint("test_joint").getIMotionCube().getStatusWord());
-  march4.getJoint("test_joint")
-      .getIMotionCube()
-      .parseMotionError(march4.getJoint("test_joint").getIMotionCube().getMotionError());
-  march4.getJoint("test_joint")
-      .getIMotionCube()
-      .parseDetailedError(march4.getJoint("test_joint").getIMotionCube().getDetailedError());
 
   march4.stopEtherCAT();
 }

--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -110,7 +110,7 @@ void MarchHardwareInterface::init()
     // Enable high voltage on the IMC
     if (joint.canActuate())
     {
-      joint.getIMotionCube().goToOperationEnabled();
+      joint.prepareActuation();
     }
   }
 


### PR DESCRIPTION
Closes #37 