### PR TITLE
Throw exception when rad command is too far from current position

### DIFF
--- a/march_hardware/src/IMotionCube.cpp
+++ b/march_hardware/src/IMotionCube.cpp
@@ -99,7 +99,8 @@ void IMotionCube::actuateRad(float targetRad)
 {
   if (std::abs(targetRad - this->getAngleRad()) > 0.05)
   {
-    ROS_ERROR("Target %f exceeds max difference of 0.05 from current %f for slave %d", targetRad, this->getAngleRad(), this->slaveIndex);
+    ROS_ERROR("Target %f exceeds max difference of 0.05 from current %f for slave %d", targetRad, this->getAngleRad(),
+              this->slaveIndex);
     throw std::runtime_error("Target exceeds max difference of 0.05 from current position");
   }
   this->actuateIU(this->encoder.RadtoIU(targetRad));

--- a/march_hardware/src/IMotionCube.cpp
+++ b/march_hardware/src/IMotionCube.cpp
@@ -99,8 +99,8 @@ void IMotionCube::actuateRad(float targetRad)
 {
   if (std::abs(targetRad - this->getAngleRad()) > 0.2)
   {
-    ROS_ERROR("Target %f exceeds max difference of 0.2 from current %f", targetRad, this->getAngleRad());
-    return;
+    ROS_ERROR("Target %f exceeds max difference of 0.2 from current %f for slave %d", targetRad, this->getAngleRad(), this->slaveIndex);
+    throw std::runtime_error("Target exceeds max difference of 0.2 from current position");
   }
   this->actuateIU(this->encoder.RadtoIU(targetRad));
 }

--- a/march_hardware/src/IMotionCube.cpp
+++ b/march_hardware/src/IMotionCube.cpp
@@ -97,7 +97,7 @@ void IMotionCube::writeInitialSettings(uint8 ecatCycleTime)
 
 void IMotionCube::actuateRad(float targetRad)
 {
-  if (std::abs(targetRad - this->getAngleRad()) > 0.2)
+  if (std::abs(targetRad - this->getAngleRad()) > 0.05)
   {
     ROS_ERROR("Target %f exceeds max difference of 0.2 from current %f for slave %d", targetRad, this->getAngleRad(), this->slaveIndex);
     throw std::runtime_error("Target exceeds max difference of 0.2 from current position");

--- a/march_hardware/src/IMotionCube.cpp
+++ b/march_hardware/src/IMotionCube.cpp
@@ -97,11 +97,11 @@ void IMotionCube::writeInitialSettings(uint8 ecatCycleTime)
 
 void IMotionCube::actuateRad(float targetRad)
 {
-  if (std::abs(targetRad - this->getAngleRad()) > 0.05)
+  if (std::abs(targetRad - this->getAngleRad()) > 0.075)
   {
-    ROS_ERROR("Target %f exceeds max difference of 0.05 from current %f for slave %d", targetRad, this->getAngleRad(),
+    ROS_ERROR("Target %f exceeds max difference of 0.075 from current %f for slave %d", targetRad, this->getAngleRad(),
               this->slaveIndex);
-    throw std::runtime_error("Target exceeds max difference of 0.05 from current position");
+    throw std::runtime_error("Target exceeds max difference of 0.075 from current position");
   }
   this->actuateIU(this->encoder.RadtoIU(targetRad));
 }

--- a/march_hardware/src/IMotionCube.cpp
+++ b/march_hardware/src/IMotionCube.cpp
@@ -99,8 +99,8 @@ void IMotionCube::actuateRad(float targetRad)
 {
   if (std::abs(targetRad - this->getAngleRad()) > 0.05)
   {
-    ROS_ERROR("Target %f exceeds max difference of 0.2 from current %f for slave %d", targetRad, this->getAngleRad(), this->slaveIndex);
-    throw std::runtime_error("Target exceeds max difference of 0.2 from current position");
+    ROS_ERROR("Target %f exceeds max difference of 0.05 from current %f for slave %d", targetRad, this->getAngleRad(), this->slaveIndex);
+    throw std::runtime_error("Target exceeds max difference of 0.05 from current position");
   }
   this->actuateIU(this->encoder.RadtoIU(targetRad));
 }


### PR DESCRIPTION
Changed the value from 0.2 to 0.05

Our max speed is 1.7 rad/s, at 100hz this means we need to move 0.017 rad per instruction at most. 0.05 was chosen to have a bit of a buffer.

NOTE: This means that if the controller has an error of more than 0.05 rad it will also trigger this limit. This needs to be tested on the exoskeleton