### PR TITLE
Enlarge error margin

### DIFF
--- a/march_hardware/src/IMotionCube.cpp
+++ b/march_hardware/src/IMotionCube.cpp
@@ -99,9 +99,9 @@ void IMotionCube::actuateRad(float targetRad)
 {
   if (std::abs(targetRad - this->getAngleRad()) > 0.27)
   {
-    ROS_ERROR("Target %f exceeds max difference of 0.075 from current %f for slave %d", targetRad, this->getAngleRad(),
+    ROS_ERROR("Target %f exceeds max difference of 0.27 from current %f for slave %d", targetRad, this->getAngleRad(),
               this->slaveIndex);
-    throw std::runtime_error("Target exceeds max difference of 0.075 from current position");
+    throw std::runtime_error("Target exceeds max difference of 0.27 from current position");
   }
   this->actuateIU(this->encoder.RadtoIU(targetRad));
 }

--- a/march_hardware/src/IMotionCube.cpp
+++ b/march_hardware/src/IMotionCube.cpp
@@ -97,7 +97,7 @@ void IMotionCube::writeInitialSettings(uint8 ecatCycleTime)
 
 void IMotionCube::actuateRad(float targetRad)
 {
-  if (std::abs(targetRad - this->getAngleRad()) > 0.075)
+  if (std::abs(targetRad - this->getAngleRad()) > 0.27)
   {
     ROS_ERROR("Target %f exceeds max difference of 0.075 from current %f for slave %d", targetRad, this->getAngleRad(),
               this->slaveIndex);


### PR DESCRIPTION
The error margin is enlarged from 0.075 to 0.27. This is done because shutting all IMC's down is less safe than a deviation between the desired and the actual position. 
The value 0.27 is determined by looking at the log files of M3 during the Cybathlon. They use the same controller variables as we do right now. And during a certain gait they had an error of 0.266 rad. 
A plot showing this error and an analysis of our gait files during training 2 can be found here: https://confluence.projectmarch.nl:8443/pages/viewpage.action?spaceKey=41TECH&title=Analysis+desired+and+target+error