### PR TITLE
Better prints for going to operation enabled

### DIFF
--- a/march_hardware/src/EtherCAT/EthercatMaster.cpp
+++ b/march_hardware/src/EtherCAT/EthercatMaster.cpp
@@ -152,14 +152,14 @@ void EthercatMaster::ethercatLoop()
     if (totalLoops >= 10 * rate)  // Every 10 seconds
     {
       float rateNotAchievedPercentage = 100 * (static_cast<float>(rateNotAchievedCount) / totalLoops);
-      if (rateNotAchievedPercentage > 10)  // If percentage greater than 10 percent, do ROS_WARN instead of ROS_INFO
+      if (rateNotAchievedPercentage > 1)  // If percentage greater than 10 percent, do ROS_WARN instead of ROS_INFO
       {
         ROS_WARN("EtherCAT rate of %d milliseconds per cycle was not achieved for %f percent of all cycles",
                  ecatCycleTimems, rateNotAchievedPercentage);
       }
       else
       {
-        ROS_INFO("EtherCAT rate of %d milliseconds per cycle was not achieved for %f percent of all cycles",
+        ROS_DEBUG("EtherCAT rate of %d milliseconds per cycle was not achieved for %f percent of all cycles",
                  ecatCycleTimems, rateNotAchievedPercentage);
       }
       totalLoops = 0;

--- a/march_hardware/src/IMotionCube.cpp
+++ b/march_hardware/src/IMotionCube.cpp
@@ -415,7 +415,7 @@ bool IMotionCube::goToOperationEnabled()
 {
   this->setControlWord(128);
 
-  ROS_INFO("Try to go to 'Switch on Disabled'");
+  ROS_INFO("     Try to go to 'Switch on Disabled'");
   bool switchOnDisabled = false;
   while (!switchOnDisabled)
   {
@@ -424,11 +424,11 @@ bool IMotionCube::goToOperationEnabled()
     int switchOnDisabledMask = 0b0000000001001111;
     int switchOnDisabledState = 64;
     switchOnDisabled = (statusWord & switchOnDisabledMask) == switchOnDisabledState;
-    ROS_INFO_STREAM_THROTTLE(0.1, "Waiting for 'Switch on Disabled': " << std::bitset<16>(statusWord));
+    ROS_INFO_STREAM_THROTTLE(0.5, "     Waiting for 'Switch on Disabled': " << std::bitset<16>(statusWord));
   }
-  ROS_INFO("Switch on Disabled!");
+  ROS_INFO("     Switch on Disabled!");
 
-  ROS_INFO("Try to go to 'Ready to Switch On'");
+  ROS_INFO("     Try to go to 'Ready to Switch On'");
   bool readyToSwitchOn = false;
   while (!readyToSwitchOn)
   {
@@ -437,11 +437,11 @@ bool IMotionCube::goToOperationEnabled()
     int readyToSwitchOnMask = 0b0000000001101111;
     int readyToSwitchOnState = 33;
     readyToSwitchOn = (statusWord & readyToSwitchOnMask) == readyToSwitchOnState;
-    ROS_INFO_STREAM_THROTTLE(0.1, "Waiting for 'Ready to Switch On': " << std::bitset<16>(statusWord));
+    ROS_INFO_STREAM_THROTTLE(0.5, "     Waiting for 'Ready to Switch On': " << std::bitset<16>(statusWord));
   }
-  ROS_INFO("Ready to Switch On!");
+  ROS_INFO("     Ready to Switch On!");
 
-  ROS_INFO("Try to go to 'Switched On'");
+  ROS_INFO("     Try to go to 'Switched On'");
   bool switchedOn = false;
   while (!switchedOn)
   {
@@ -450,9 +450,9 @@ bool IMotionCube::goToOperationEnabled()
     int switchedOnMask = 0b0000000001101111;
     int switchedOnState = 35;
     switchedOn = (statusWord & switchedOnMask) == switchedOnState;
-    ROS_INFO_STREAM_THROTTLE(0.1, "Waiting for 'Switched On': " << std::bitset<16>(statusWord));
+    ROS_INFO_STREAM_THROTTLE(0.5, "     Waiting for 'Switched On': " << std::bitset<16>(statusWord));
   }
-  ROS_INFO("Switched On!");
+  ROS_INFO("     Switched On!");
 
   // If ActualPosition is not defined in PDOmapping, a fatal error is thrown
   // because of safety reasons
@@ -474,7 +474,7 @@ bool IMotionCube::goToOperationEnabled()
     throw std::domain_error("Encoder is not functioning properly");
   }
 
-  ROS_INFO("Try to go to 'Operation Enabled'");
+  ROS_INFO("     Try to go to 'Operation Enabled'");
   bool operationEnabled = false;
   while (!operationEnabled)
   {
@@ -483,9 +483,9 @@ bool IMotionCube::goToOperationEnabled()
     int operationEnabledMask = 0b0000000001101111;
     int operationEnabledState = 39;
     operationEnabled = (statusWord & operationEnabledMask) == operationEnabledState;
-    ROS_INFO_STREAM_THROTTLE(0.1, "Waiting for 'Operation Enabled': " << std::bitset<16>(statusWord));
+    ROS_INFO_STREAM_THROTTLE(0.5, "     Waiting for 'Operation Enabled': " << std::bitset<16>(statusWord));
   }
-  ROS_INFO("Operation Enabled!");
+  ROS_INFO("     Operation Enabled!");
 }
 
 bool IMotionCube::resetIMotionCube()

--- a/march_hardware/src/IMotionCube.cpp
+++ b/march_hardware/src/IMotionCube.cpp
@@ -415,7 +415,7 @@ bool IMotionCube::goToOperationEnabled()
 {
   this->setControlWord(128);
 
-  ROS_INFO("     Try to go to 'Switch on Disabled'");
+  ROS_INFO("\tTry to go to 'Switch on Disabled'");
   bool switchOnDisabled = false;
   while (!switchOnDisabled)
   {
@@ -424,11 +424,11 @@ bool IMotionCube::goToOperationEnabled()
     int switchOnDisabledMask = 0b0000000001001111;
     int switchOnDisabledState = 64;
     switchOnDisabled = (statusWord & switchOnDisabledMask) == switchOnDisabledState;
-    ROS_INFO_STREAM_THROTTLE(0.5, "     Waiting for 'Switch on Disabled': " << std::bitset<16>(statusWord));
+    ROS_INFO_STREAM_THROTTLE(0.5, "\tWaiting for 'Switch on Disabled': " << std::bitset<16>(statusWord));
   }
-  ROS_INFO("     Switch on Disabled!");
+  ROS_INFO("\tSwitch on Disabled!");
 
-  ROS_INFO("     Try to go to 'Ready to Switch On'");
+  ROS_INFO("\tTry to go to 'Ready to Switch On'");
   bool readyToSwitchOn = false;
   while (!readyToSwitchOn)
   {
@@ -437,11 +437,11 @@ bool IMotionCube::goToOperationEnabled()
     int readyToSwitchOnMask = 0b0000000001101111;
     int readyToSwitchOnState = 33;
     readyToSwitchOn = (statusWord & readyToSwitchOnMask) == readyToSwitchOnState;
-    ROS_INFO_STREAM_THROTTLE(0.5, "     Waiting for 'Ready to Switch On': " << std::bitset<16>(statusWord));
+    ROS_INFO_STREAM_THROTTLE(0.5, "\tWaiting for 'Ready to Switch On': " << std::bitset<16>(statusWord));
   }
-  ROS_INFO("     Ready to Switch On!");
+  ROS_INFO("\tReady to Switch On!");
 
-  ROS_INFO("     Try to go to 'Switched On'");
+  ROS_INFO("\tTry to go to 'Switched On'");
   bool switchedOn = false;
   while (!switchedOn)
   {
@@ -450,9 +450,9 @@ bool IMotionCube::goToOperationEnabled()
     int switchedOnMask = 0b0000000001101111;
     int switchedOnState = 35;
     switchedOn = (statusWord & switchedOnMask) == switchedOnState;
-    ROS_INFO_STREAM_THROTTLE(0.5, "     Waiting for 'Switched On': " << std::bitset<16>(statusWord));
+    ROS_INFO_STREAM_THROTTLE(0.5, "\tWaiting for 'Switched On': " << std::bitset<16>(statusWord));
   }
-  ROS_INFO("     Switched On!");
+  ROS_INFO("\tSwitched On!");
 
   // If ActualPosition is not defined in PDOmapping, a fatal error is thrown
   // because of safety reasons
@@ -474,7 +474,7 @@ bool IMotionCube::goToOperationEnabled()
     throw std::domain_error("Encoder is not functioning properly");
   }
 
-  ROS_INFO("     Try to go to 'Operation Enabled'");
+  ROS_INFO("\tTry to go to 'Operation Enabled'");
   bool operationEnabled = false;
   while (!operationEnabled)
   {
@@ -483,9 +483,9 @@ bool IMotionCube::goToOperationEnabled()
     int operationEnabledMask = 0b0000000001101111;
     int operationEnabledState = 39;
     operationEnabled = (statusWord & operationEnabledMask) == operationEnabledState;
-    ROS_INFO_STREAM_THROTTLE(0.5, "     Waiting for 'Operation Enabled': " << std::bitset<16>(statusWord));
+    ROS_INFO_STREAM_THROTTLE(0.5, "\tWaiting for 'Operation Enabled': " << std::bitset<16>(statusWord));
   }
-  ROS_INFO("     Operation Enabled!");
+  ROS_INFO("\tOperation Enabled!");
 }
 
 bool IMotionCube::resetIMotionCube()

--- a/march_hardware/src/IMotionCube.cpp
+++ b/march_hardware/src/IMotionCube.cpp
@@ -63,7 +63,7 @@ void IMotionCube::validateMosiPDOs()
 // Set configuration parameters to the IMC
 void IMotionCube::writeInitialSettings(uint8 ecatCycleTime)
 {
-  ROS_INFO("IMotionCube::writeInitialSettings");
+  ROS_DEBUG("IMotionCube::writeInitialSettings");
   bool success = true;
   // sdo_bit32(slaveIndex, address, subindex, value);
   // mode of operation

--- a/march_hardware/src/Joint.cpp
+++ b/march_hardware/src/Joint.cpp
@@ -55,7 +55,9 @@ void Joint::prepareActuation()
 {
   if (this->allowActuation)
   {
+    ROS_INFO("Trying to prepare joint %s for actuation", this->name.c_str());
     this->iMotionCube.goToOperationEnabled();
+    ROS_INFO("Joint %s successfully prepared for actuation", this->name.c_str());
   }
   else
   {

--- a/march_hardware/src/Joint.cpp
+++ b/march_hardware/src/Joint.cpp
@@ -55,7 +55,7 @@ void Joint::prepareActuation()
 {
   if (this->allowActuation)
   {
-    ROS_INFO("Trying to prepare joint %s for actuation", this->name.c_str());
+    ROS_INFO("Preparing joint %s for actuation", this->name.c_str());
     this->iMotionCube.goToOperationEnabled();
     ROS_INFO("Joint %s successfully prepared for actuation", this->name.c_str());
   }

--- a/march_hardware/src/Joint.cpp
+++ b/march_hardware/src/Joint.cpp
@@ -57,7 +57,7 @@ void Joint::prepareActuation()
   {
     ROS_INFO("Preparing joint %s for actuation", this->name.c_str());
     this->iMotionCube.goToOperationEnabled();
-    ROS_INFO("Joint %s successfully prepared for actuation", this->name.c_str());
+    ROS_INFO("\tJoint %s successfully prepared for actuation", this->name.c_str());
   }
   else
   {

--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -79,7 +79,7 @@ void MarchHardwareInterface::init()
   {
     SoftJointLimits soft_limits;
     getSoftJointLimits(model.getJoint(joint_names_[i]), soft_limits);
-    ROS_INFO("soft_limits_ (%f, %f).", soft_limits.min_position, soft_limits.max_position);
+    ROS_INFO("%s soft_limits_ (%f, %f).", joint_names_[i].c_str(), soft_limits.min_position, soft_limits.max_position);
     soft_limits_[i] = soft_limits;
   }
 


### PR DESCRIPTION
reduced print rate from every 0.1 sec to every 0.5 sec
add prints before and after indicating which joint is being turned on
add indentation to make it more clear to which joint all these prints belong

these prints have bothered me for a while, imo this is much better
ofc this is bit personal preference, if you have ideas about it feel free to tell me/change stuff