### PR TITLE
Add torque objects to PDO mapping

### DIFF
--- a/march_hardware/include/march_hardware/PDOmap.h
+++ b/march_hardware/include/march_hardware/PDOmap.h
@@ -46,6 +46,7 @@ enum class IMCObjectName
   MotorPosition,
   ControlWord,
   TargetPosition,
+  TargetTorque,
   QuickStopDeceleration,
   QuickStopOption
 };

--- a/march_hardware/src/IMotionCube.cpp
+++ b/march_hardware/src/IMotionCube.cpp
@@ -32,6 +32,7 @@ void IMotionCube::mapMisoPDOs()
   PDOmap pdoMapMISO = PDOmap();
   pdoMapMISO.addObject(IMCObjectName::StatusWord);      // Compulsory!
   pdoMapMISO.addObject(IMCObjectName::ActualPosition);  // Compulsory!
+  pdoMapMISO.addObject(IMCObjectName::ActualTorque);    // Compulsory!
   pdoMapMISO.addObject(IMCObjectName::MotionErrorRegister);
   pdoMapMISO.addObject(IMCObjectName::DetailedErrorRegister);
   this->misoByteOffsets = pdoMapMISO.map(this->slaveIndex, dataDirection::miso);
@@ -44,6 +45,7 @@ void IMotionCube::mapMosiPDOs()
   PDOmap pdoMapMOSI = PDOmap();
   pdoMapMOSI.addObject(IMCObjectName::ControlWord);  // Compulsory!
   pdoMapMOSI.addObject(IMCObjectName::TargetPosition);
+  pdoMapMOSI.addObject(IMCObjectName::TargetTorque);
   this->mosiByteOffsets = pdoMapMOSI.map(this->slaveIndex, dataDirection::mosi);
 }
 
@@ -52,6 +54,8 @@ void IMotionCube::validateMisoPDOs()
 {
   ROS_ASSERT_MSG(this->misoByteOffsets.count(IMCObjectName::StatusWord) == 1, "StatusWord not mapped");
   ROS_ASSERT_MSG(this->misoByteOffsets.count(IMCObjectName::ActualPosition) == 1, "ActualPosition not mapped");
+  ROS_ASSERT_MSG(this->mosiByteOffsets.count(IMCObjectName::TargetPosition) == 1, "TargetPosition not mapped");
+  ROS_ASSERT_MSG(this->mosiByteOffsets.count(IMCObjectName::TargetTorque) == 1, "TargetTorque not mapped");
 }
 
 // Checks if the compulsory MOSI PDO objects are mapped
@@ -469,8 +473,8 @@ bool IMotionCube::goToOperationEnabled()
   else
   {
     ROS_FATAL("Encoder of iMotionCube (with slaveindex %d) is not functioning properly, read value %d, min value "
-              "is %d, max value is %d. Shutting down", this->slaveIndex,
-              angleRead, this->encoder.getMinPositionIU(), this->encoder.getMaxPositionIU());
+              "is %d, max value is %d. Shutting down",
+              this->slaveIndex, angleRead, this->encoder.getMinPositionIU(), this->encoder.getMaxPositionIU());
     throw std::domain_error("Encoder is not functioning properly");
   }
 

--- a/march_hardware/src/PDOmap.cpp
+++ b/march_hardware/src/PDOmap.cpp
@@ -149,6 +149,7 @@ void PDOmap::initAllObjects()
   this->allObjects[IMCObjectName::MotorPosition] = IMCObject(0x2088, 32);
   this->allObjects[IMCObjectName::ControlWord] = IMCObject(0x6040, 16);
   this->allObjects[IMCObjectName::TargetPosition] = IMCObject(0x607A, 32);
+  this->allObjects[IMCObjectName::TargetTorque] = IMCObject(0x6071, 16);
   this->allObjects[IMCObjectName::QuickStopDeceleration] = IMCObject(0x6085, 32);
   this->allObjects[IMCObjectName::QuickStopOption] = IMCObject(0x605A, 16);
   // etc...


### PR DESCRIPTION
For the future torque mode, we need to map actualtorque and targettorque in the PDO mapping.