### PR TITLE
change min/max pos in encoder class to pos/neg soft- and hardlimits

### DIFF
--- a/march_hardware/include/march_hardware/Encoder.h
+++ b/march_hardware/include/march_hardware/Encoder.h
@@ -12,9 +12,13 @@ class Encoder
 private:
   int slaveIndex;
   int totalPositions;
-  int minPositionIU;
-  int maxPositionIU;
+
+  int positiveHardLimitIU;
+  int negativeHardLimitIU;
+  int positiveSoftLimitIU;
+  int negativeSoftLimitIU;
   int zeroPositionIU;
+
   float safetyMarginRad;
 
 public:
@@ -29,20 +33,23 @@ public:
   float IUtoRad(int iu);
   int RadtoIU(float rad);
 
-  bool isValidTargetPositionIU(int targetPosIU);
+  bool isWithinHardLimits(int positionIU);
+  bool isWithinSoftLimits(int positionIU);
 
-  bool isValidPositionIU(int positionIU);
   void setSlaveIndex(int slaveIndex);
 
   int getSlaveIndex() const;
-  int getMinPositionIU() const;
-  int getMaxPositionIU() const;
+  int getPositiveSoftLimit() const;
+  int getNegativeSoftLimit() const;
+  int getPositiveHardLimit() const;
+  int getNegativeHardLimit() const;
 
   /** @brief Override comparison operator */
   friend bool operator==(const Encoder& lhs, const Encoder& rhs)
   {
     return lhs.slaveIndex == rhs.slaveIndex && lhs.totalPositions == rhs.totalPositions &&
-           lhs.minPositionIU == rhs.minPositionIU && lhs.maxPositionIU == rhs.maxPositionIU &&
+           lhs.positiveSoftLimitIU == rhs.positiveSoftLimitIU && lhs.negativeSoftLimitIU == rhs.negativeSoftLimitIU &&
+           lhs.positiveHardLimitIU == rhs.positiveHardLimitIU && lhs.negativeHardLimitIU == rhs.negativeHardLimitIU &&
            lhs.zeroPositionIU == rhs.zeroPositionIU && lhs.safetyMarginRad == rhs.safetyMarginRad;
   }
   /** @brief Override stream operator for clean printing */
@@ -50,8 +57,10 @@ public:
   {
     return os << "slaveIndex: " << encoder.slaveIndex << ", "
               << "totalPositions: " << encoder.totalPositions << ", "
-              << "minPositionIU: " << encoder.minPositionIU << ", "
-              << "maxPositionIU: " << encoder.maxPositionIU << ", "
+              << "positiveHardLimit: " << encoder.positiveHardLimitIU << ", "
+              << "negativeHardLimit: " << encoder.negativeHardLimitIU << ", "
+              << "positiveSoftLimit: " << encoder.positiveSoftLimitIU << ", "
+              << "negativeSoftLimit: " << encoder.negativeSoftLimitIU << ", "
               << "zeroPositionIU: " << encoder.zeroPositionIU << ", "
               << "safetyMarginRad: " << encoder.safetyMarginRad;
   }

--- a/march_hardware/include/march_hardware/Encoder.h
+++ b/march_hardware/include/march_hardware/Encoder.h
@@ -13,10 +13,10 @@ private:
   int slaveIndex;
   int totalPositions;
 
-  int positiveHardLimitIU;
-  int negativeHardLimitIU;
-  int positiveSoftLimitIU;
-  int negativeSoftLimitIU;
+  int upperHardLimitIU;
+  int lowerHardLimitIU;
+  int upperSoftLimitIU;
+  int lowerSoftLimitIU;
   int zeroPositionIU;
 
   float safetyMarginRad;
@@ -39,17 +39,17 @@ public:
   void setSlaveIndex(int slaveIndex);
 
   int getSlaveIndex() const;
-  int getPositiveSoftLimitIU() const;
-  int getNegativeSoftLimitIU() const;
-  int getPositiveHardLimitIU() const;
-  int getNegativeHardLimitIU() const;
+  int getUpperSoftLimitIU() const;
+  int getLowerSoftLimitIU() const;
+  int getUpperHardLimitIU() const;
+  int getLowerHardLimitIU() const;
 
   /** @brief Override comparison operator */
   friend bool operator==(const Encoder& lhs, const Encoder& rhs)
   {
     return lhs.slaveIndex == rhs.slaveIndex && lhs.totalPositions == rhs.totalPositions &&
-           lhs.positiveSoftLimitIU == rhs.positiveSoftLimitIU && lhs.negativeSoftLimitIU == rhs.negativeSoftLimitIU &&
-           lhs.positiveHardLimitIU == rhs.positiveHardLimitIU && lhs.negativeHardLimitIU == rhs.negativeHardLimitIU &&
+           lhs.upperSoftLimitIU == rhs.upperSoftLimitIU && lhs.lowerSoftLimitIU == rhs.lowerSoftLimitIU &&
+           lhs.upperHardLimitIU == rhs.upperHardLimitIU && lhs.lowerHardLimitIU == rhs.lowerHardLimitIU &&
            lhs.zeroPositionIU == rhs.zeroPositionIU && lhs.safetyMarginRad == rhs.safetyMarginRad;
   }
   /** @brief Override stream operator for clean printing */
@@ -57,10 +57,10 @@ public:
   {
     return os << "slaveIndex: " << encoder.slaveIndex << ", "
               << "totalPositions: " << encoder.totalPositions << ", "
-              << "positiveHardLimit: " << encoder.positiveHardLimitIU << ", "
-              << "negativeHardLimit: " << encoder.negativeHardLimitIU << ", "
-              << "positiveSoftLimit: " << encoder.positiveSoftLimitIU << ", "
-              << "negativeSoftLimit: " << encoder.negativeSoftLimitIU << ", "
+              << "upperHardLimit: " << encoder.upperHardLimitIU << ", "
+              << "lowerHardLimit: " << encoder.lowerHardLimitIU << ", "
+              << "upperSoftLimit: " << encoder.upperSoftLimitIU << ", "
+              << "lowerSoftLimit: " << encoder.lowerSoftLimitIU << ", "
               << "zeroPositionIU: " << encoder.zeroPositionIU << ", "
               << "safetyMarginRad: " << encoder.safetyMarginRad;
   }

--- a/march_hardware/include/march_hardware/Encoder.h
+++ b/march_hardware/include/march_hardware/Encoder.h
@@ -33,16 +33,16 @@ public:
   float IUtoRad(int iu);
   int RadtoIU(float rad);
 
-  bool isWithinHardLimits(int positionIU);
-  bool isWithinSoftLimits(int positionIU);
+  bool isWithinHardLimitsIU(int positionIU);
+  bool isWithinSoftLimitsIU(int positionIU);
 
   void setSlaveIndex(int slaveIndex);
 
   int getSlaveIndex() const;
-  int getPositiveSoftLimit() const;
-  int getNegativeSoftLimit() const;
-  int getPositiveHardLimit() const;
-  int getNegativeHardLimit() const;
+  int getPositiveSoftLimitIU() const;
+  int getNegativeSoftLimitIU() const;
+  int getPositiveHardLimitIU() const;
+  int getNegativeHardLimitIU() const;
 
   /** @brief Override comparison operator */
   friend bool operator==(const Encoder& lhs, const Encoder& rhs)

--- a/march_hardware/src/Encoder.cpp
+++ b/march_hardware/src/Encoder.cpp
@@ -17,18 +17,18 @@ Encoder::Encoder(int numberOfBits, int minPositionIU, int maxPositionIU, int zer
 
   this->safetyMarginRad = safetyMarginRad;
   this->slaveIndex = -1;
-  this->positiveHardLimitIU = maxPositionIU;
-  this->negativeHardLimitIU = minPositionIU;
+  this->upperHardLimitIU = maxPositionIU;
+  this->lowerHardLimitIU = minPositionIU;
   this->zeroPositionIU = zeroPositionIU;
   int safetyMarginIU = RadtoIU(safetyMarginRad) - this->zeroPositionIU;
-  this->positiveSoftLimitIU = this->positiveHardLimitIU - safetyMarginIU;
-  this->negativeSoftLimitIU = this->negativeHardLimitIU + safetyMarginIU;
+  this->upperSoftLimitIU = this->upperHardLimitIU - safetyMarginIU;
+  this->lowerSoftLimitIU = this->lowerHardLimitIU + safetyMarginIU;
 
-  ROS_ASSERT_MSG(this->negativeSoftLimitIU < this->positiveSoftLimitIU,
+  ROS_ASSERT_MSG(this->lowerSoftLimitIU < this->upperSoftLimitIU,
                  "Invalid range of motion. Safety margin too large or "
                  "min/max position invalid. Minposition: %i IU, Maxposition: "
                  "%i IU, safetyMargin: %f rad",
-                 this->negativeSoftLimitIU, this->positiveSoftLimitIU, this->safetyMarginRad);
+                 this->lowerSoftLimitIU, this->upperSoftLimitIU, this->safetyMarginRad);
 }
 
 float Encoder::getAngleRad(uint8_t ActualPositionByteOffset)
@@ -69,32 +69,32 @@ int Encoder::getSlaveIndex() const
 
 bool Encoder::isWithinHardLimitsIU(int positionIU)
 {
-  return (positionIU > this->negativeHardLimitIU && positionIU < this->positiveHardLimitIU);
+  return (positionIU > this->lowerHardLimitIU && positionIU < this->upperHardLimitIU);
 }
 
 bool Encoder::isWithinSoftLimitsIU(int positionIU)
 {
-  return (positionIU > this->negativeSoftLimitIU && positionIU < this->positiveSoftLimitIU);
+  return (positionIU > this->lowerSoftLimitIU && positionIU < this->upperSoftLimitIU);
 }
 
-int Encoder::getPositiveSoftLimitIU() const
+int Encoder::getUpperSoftLimitIU() const
 {
-  return positiveSoftLimitIU;
+  return upperSoftLimitIU;
 }
 
-int Encoder::getNegativeSoftLimitIU() const
+int Encoder::getLowerSoftLimitIU() const
 {
-  return negativeSoftLimitIU;
+  return lowerSoftLimitIU;
 }
 
-int Encoder::getPositiveHardLimitIU() const
+int Encoder::getUpperHardLimitIU() const
 {
-  return positiveHardLimitIU;
+  return upperHardLimitIU;
 }
 
-int Encoder::getNegativeHardLimitIU() const
+int Encoder::getLowerHardLimitIU() const
 {
-  return negativeHardLimitIU;
+  return lowerHardLimitIU;
 }
 
 }  // namespace march4cpp

--- a/march_hardware/src/Encoder.cpp
+++ b/march_hardware/src/Encoder.cpp
@@ -17,18 +17,18 @@ Encoder::Encoder(int numberOfBits, int minPositionIU, int maxPositionIU, int zer
 
   this->safetyMarginRad = safetyMarginRad;
   this->slaveIndex = -1;
-
+  this->positiveHardLimitIU = maxPositionIU;
+  this->negativeHardLimitIU = minPositionIU;
   this->zeroPositionIU = zeroPositionIU;
-
   int safetyMarginIU = RadtoIU(safetyMarginRad) - this->zeroPositionIU;
+  this->positiveSoftLimitIU = this->positiveHardLimitIU - safetyMarginIU;
+  this->negativeSoftLimitIU = this->negativeHardLimitIU + safetyMarginIU;
 
-  this->minPositionIU = minPositionIU + safetyMarginIU;
-  this->maxPositionIU = maxPositionIU - safetyMarginIU;
-
-  ROS_ASSERT_MSG(this->minPositionIU < this->maxPositionIU, "Invalid range of motion. Safety margin too large or "
-                                                            "min/max position invalid. Minposition: %i, Maxposition: "
-                                                            "%i, safetyMargin: %f",
-                 this->minPositionIU, this->maxPositionIU, this->safetyMarginRad);
+  ROS_ASSERT_MSG(this->negativeSoftLimitIU < this->positiveSoftLimitIU,
+                 "Invalid range of motion. Safety margin too large or "
+                 "min/max position invalid. Minposition: %i IU, Maxposition: "
+                 "%i IU, safetyMargin: %f rad",
+                 this->negativeSoftLimitIU, this->positiveSoftLimitIU, this->safetyMarginRad);
 }
 
 float Encoder::getAngleRad(uint8_t ActualPositionByteOffset)
@@ -67,24 +67,34 @@ int Encoder::getSlaveIndex() const
   return this->slaveIndex;
 }
 
-bool Encoder::isValidTargetPositionIU(int targetPosIU)
+bool Encoder::isWithinHardLimits(int positionIU)
 {
-  return (targetPosIU > this->minPositionIU && targetPosIU < this->maxPositionIU);
+  return (positionIU > this->negativeHardLimitIU && positionIU < this->positiveHardLimitIU);
 }
 
-int Encoder::getMinPositionIU() const
+bool Encoder::isWithinSoftLimits(int positionIU)
 {
-  return minPositionIU;
+  return (positionIU > this->negativeSoftLimitIU && positionIU < this->positiveSoftLimitIU);
 }
 
-int Encoder::getMaxPositionIU() const
+int Encoder::getPositiveSoftLimit() const
 {
-  return maxPositionIU;
+  return positiveSoftLimitIU;
 }
 
-bool Encoder::isValidPositionIU(int positionIU)
+int Encoder::getNegativeSoftLimit() const
 {
-  return positionIU > 0 && positionIU <= this->totalPositions;
+  return negativeSoftLimitIU;
+}
+
+int Encoder::getPositiveHardLimit() const
+{
+  return positiveHardLimitIU;
+}
+
+int Encoder::getNegativeHardLimit() const
+{
+  return negativeHardLimitIU;
 }
 
 }  // namespace march4cpp

--- a/march_hardware/src/Encoder.cpp
+++ b/march_hardware/src/Encoder.cpp
@@ -67,32 +67,32 @@ int Encoder::getSlaveIndex() const
   return this->slaveIndex;
 }
 
-bool Encoder::isWithinHardLimits(int positionIU)
+bool Encoder::isWithinHardLimitsIU(int positionIU)
 {
   return (positionIU > this->negativeHardLimitIU && positionIU < this->positiveHardLimitIU);
 }
 
-bool Encoder::isWithinSoftLimits(int positionIU)
+bool Encoder::isWithinSoftLimitsIU(int positionIU)
 {
   return (positionIU > this->negativeSoftLimitIU && positionIU < this->positiveSoftLimitIU);
 }
 
-int Encoder::getPositiveSoftLimit() const
+int Encoder::getPositiveSoftLimitIU() const
 {
   return positiveSoftLimitIU;
 }
 
-int Encoder::getNegativeSoftLimit() const
+int Encoder::getNegativeSoftLimitIU() const
 {
   return negativeSoftLimitIU;
 }
 
-int Encoder::getPositiveHardLimit() const
+int Encoder::getPositiveHardLimitIU() const
 {
   return positiveHardLimitIU;
 }
 
-int Encoder::getNegativeHardLimit() const
+int Encoder::getNegativeHardLimitIU() const
 {
   return negativeHardLimitIU;
 }

--- a/march_hardware/src/Encoder.cpp
+++ b/march_hardware/src/Encoder.cpp
@@ -26,9 +26,10 @@ Encoder::Encoder(int numberOfBits, int minPositionIU, int maxPositionIU, int zer
 
   ROS_ASSERT_MSG(this->lowerSoftLimitIU < this->upperSoftLimitIU,
                  "Invalid range of motion. Safety margin too large or "
-                 "min/max position invalid. Minposition: %i IU, Maxposition: "
-                 "%i IU, safetyMargin: %f rad",
-                 this->lowerSoftLimitIU, this->upperSoftLimitIU, this->safetyMarginRad);
+                 "min/max position invalid. lowerSoftLimit: %i IU, upperSoftLimit: "
+                 "%i IU. lowerHardLimit: %i IU, upperHardLimit %i IU. safetyMargin: %f rad = %i IU",
+                 this->lowerSoftLimitIU, this->upperSoftLimitIU, this->lowerHardLimitIU, this->upperHardLimitIU,
+                 this->safetyMarginRad, safetyMarginIU);
 }
 
 float Encoder::getAngleRad(uint8_t ActualPositionByteOffset)

--- a/march_hardware/src/IMotionCube.cpp
+++ b/march_hardware/src/IMotionCube.cpp
@@ -83,9 +83,9 @@ void IMotionCube::writeInitialSettings(uint8 ecatCycleTime)
   success &= sdo_bit32(slaveIndex, 0x6093, 2, 1);
 
   // position limit -- min position
-  success &= sdo_bit32(slaveIndex, 0x607D, 1, this->encoder.getNegativeSoftLimit());
+  success &= sdo_bit32(slaveIndex, 0x607D, 1, this->encoder.getLowerSoftLimitIU());
   // position limit -- max position
-  success &= sdo_bit32(slaveIndex, 0x607D, 2, this->encoder.getPositiveSoftLimit());
+  success &= sdo_bit32(slaveIndex, 0x607D, 2, this->encoder.getUpperSoftLimitIU());
 
   // Quick stop option
   success &= sdo_bit16(slaveIndex, 0x605A, 0, 6);
@@ -113,10 +113,10 @@ void IMotionCube::actuateRad(float targetRad)
 
 void IMotionCube::actuateIU(int targetIU)
 {
-  if (!this->encoder.isWithinSoftLimits(targetIU))
+  if (!this->encoder.isWithinSoftLimitsIU(targetIU))
   {
     ROS_ERROR("Position %i is invalid for slave %d. (%d, %d)", targetIU, this->slaveIndex,
-              this->encoder.getNegativeSoftLimit(), this->encoder.getPositiveSoftLimit());
+              this->encoder.getLowerSoftLimitIU(), this->encoder.getUpperSoftLimitIU());
     throw std::runtime_error("Invalid IU actuate command.");
   }
 
@@ -464,7 +464,7 @@ bool IMotionCube::goToOperationEnabled()
   int angleRead = this->encoder.getAngleIU(this->misoByteOffsets[IMCObjectName::ActualPosition]);
   //  If the encoder is functioning correctly, move the joint to its current
   //  position. Otherwise shutdown
-  if (this->encoder.isWithinHardLimits(angleRead) && angleRead != 0)
+  if (this->encoder.isWithinHardLimitsIU(angleRead) && angleRead != 0)
   {
     this->actuateIU(angleRead);
   }
@@ -472,7 +472,7 @@ bool IMotionCube::goToOperationEnabled()
   {
     ROS_FATAL("Encoder of iMotionCube (with slaveindex %d) is not functioning properly, read value %d, min value "
               "is %d, max value is %d. Shutting down",
-              this->slaveIndex, angleRead, this->encoder.getNegativeHardLimit(), this->encoder.getPositiveHardLimit());
+              this->slaveIndex, angleRead, this->encoder.getLowerHardLimitIU(), this->encoder.getUpperHardLimitIU());
     throw std::domain_error("Encoder is not functioning properly");
   }
 


### PR DESCRIPTION
Closes #121 

Refactors the Encoder class to have both hardlimits and softlimits. This means that when actuating to a certain position, there is the possibility to check whether the targetposition is within softlimits, while before homing there is also the possibility to check if joints are within hardlimits.