### PR TITLE
Add actuateTorque method to iMotionCube and Joint

### DIFF
--- a/march_hardware/include/march_hardware/ActuationMode.h
+++ b/march_hardware/include/march_hardware/ActuationMode.h
@@ -13,6 +13,7 @@ public:
   enum Value : int
   {
     position,
+    torque,
     unknown,
   };
 
@@ -31,6 +32,10 @@ public:
     {
       this->value = unknown;
     }
+    else if (actuationMode == "torque")
+    {
+      this->value = torque;
+    }
     else
     {
       ROS_WARN("Actuation mode (%s) is not recognized, setting to unknown mode", actuationMode.c_str());
@@ -43,6 +48,10 @@ public:
     if (value == position)
     {
       return 8;
+    }
+    else if (value == torque)
+    {
+      return 10;
     }
   }
 
@@ -67,6 +76,8 @@ public:
     {
       case position:
         return "position";
+      case torque:
+        return "torque";
       default:
         ROS_WARN("Actuationmode (%i) is neither 'torque' or 'position", value);
         return "unknown";

--- a/march_hardware/include/march_hardware/IMotionCube.h
+++ b/march_hardware/include/march_hardware/IMotionCube.h
@@ -62,6 +62,7 @@ public:
   void setControlWord(uint16 controlWord);
 
   void actuateRad(float targetRad);
+  void actuateTorque(int targetTorque);
 
   std::string parseStatusWord(uint16 statusWord);
   IMCState getState(uint16 statusWord);

--- a/march_hardware/include/march_hardware/Joint.h
+++ b/march_hardware/include/march_hardware/Joint.h
@@ -34,6 +34,7 @@ public:
   void resetIMotionCube();
 
   void actuateRad(float targetPositionRad);
+  void actuateTorque(int targetTorque);
 
   float getAngleRad();
   float getTorque();

--- a/march_hardware/src/IMotionCube.cpp
+++ b/march_hardware/src/IMotionCube.cpp
@@ -112,8 +112,8 @@ void IMotionCube::writeInitialSettings(uint8 ecatCycleTime)
 
 void IMotionCube::actuateRad(float targetRad)
 {
-  ROS_ASSERT_MSG(this->actuationMode == ActuationMode::position,
-                 "trying to actuate rad, while actuationmode = %s", this->actuationMode.toString().c_str());
+  ROS_ASSERT_MSG(this->actuationMode == ActuationMode::position, "trying to actuate rad, while actuationmode = %s",
+                 this->actuationMode.toString().c_str());
 
   if (std::abs(targetRad - this->getAngleRad()) > 0.27)
   {
@@ -146,6 +146,29 @@ void IMotionCube::actuateIU(int targetIU)
   ROS_DEBUG("Trying to actuate slave %d, soem location %d to targetposition %d", this->slaveIndex,
             targetPositionLocation, targetPosition.i);
   set_output_bit32(this->slaveIndex, targetPositionLocation, targetPosition);
+}
+
+void IMotionCube::actuateTorque(int targetTorque)
+{
+  ROS_ASSERT_MSG(this->actuationMode == ActuationMode::torque, "trying to actuate torque, while actuationmode = %s",
+                 this->actuationMode.toString().c_str());
+
+  // The targetTorque must not exceed the value of 27300 IU, this is 25 A. This value could be increased in the future (to 30A) with good reasoning.
+  ROS_ASSERT_MSG(targetTorque < 27300, "Torque of %d is too high.", targetTorque);
+
+  union bit16 targetTorqueStruct;
+  targetTorqueStruct.i = targetTorque;
+
+  if (this->mosiByteOffsets.count(IMCObjectName::TargetTorque) != 1)
+  {
+    ROS_WARN("TargetTorque not defined in PDO mapping, so can't do actuateTorque");
+    return;
+  }
+  uint8 targetTorqueLocation = this->mosiByteOffsets[IMCObjectName::TargetTorque];
+
+  ROS_DEBUG("Trying to actuate slave %d, soem location %d with target torque %d", this->slaveIndex,
+            targetTorqueLocation, targetTorqueStruct.i);
+  set_output_bit16(this->slaveIndex, targetTorqueLocation, targetTorqueStruct);
 }
 
 float IMotionCube::getAngleRad()

--- a/march_hardware/src/IMotionCube.cpp
+++ b/march_hardware/src/IMotionCube.cpp
@@ -153,7 +153,8 @@ void IMotionCube::actuateTorque(int targetTorque)
   ROS_ASSERT_MSG(this->actuationMode == ActuationMode::torque, "trying to actuate torque, while actuationmode = %s",
                  this->actuationMode.toString().c_str());
 
-  // The targetTorque must not exceed the value of 27300 IU, this is 25 A. This value could be increased in the future (to 30A) with good reasoning.
+  // The targetTorque must not exceed the value of 27300 IU, this is 25 A. This value could be increased in the future
+  // (to 30A) with good reasoning.
   ROS_ASSERT_MSG(targetTorque < 27300, "Torque of %d is too high.", targetTorque);
 
   union bit16 targetTorqueStruct;

--- a/march_hardware/src/Joint.cpp
+++ b/march_hardware/src/Joint.cpp
@@ -44,10 +44,9 @@ void Joint::resetIMotionCube()
 
 void Joint::actuateRad(float targetPositionRad)
 {
-  ROS_ASSERT_MSG(this->allowActuation,
-                 "Joint %s is not allowed to actuate, "
-                 "yet its actuate method has been "
-                 "called.",
+  ROS_ASSERT_MSG(this->allowActuation, "Joint %s is not allowed to actuate, "
+                                       "yet its actuate method has been "
+                                       "called.",
                  this->name.c_str());
   // TODO(BaCo) check that the position is allowed and does not exceed (torque)
   // limits.
@@ -62,6 +61,15 @@ float Joint::getAngleRad()
     return -1;
   }
   return this->iMotionCube.getAngleRad();
+}
+
+void Joint::actuateTorque(int targetTorque)
+{
+  ROS_ASSERT_MSG(this->allowActuation, "Joint %s is not allowed to actuate, "
+                                       "yet its actuate method has been "
+                                       "called.",
+                 this->name.c_str());
+  this->iMotionCube.actuateTorque(targetTorque);
 }
 
 float Joint::getTorque()
@@ -96,23 +104,23 @@ float Joint::getTemperature()
 
 IMotionCubeState Joint::getIMotionCubeState()
 {
-    IMotionCubeState states;
+  IMotionCubeState states;
 
-    std::bitset<16> statusWordBits = this->iMotionCube.getStatusWord();
-    states.statusWord = statusWordBits.to_string();
-    std::bitset<16> detailedErrorBits = this->iMotionCube.getDetailedError();
-    states.detailedError = detailedErrorBits.to_string();
-    std::bitset<16> motionErrorBits = this->iMotionCube.getMotionError();
-    states.motionError = motionErrorBits.to_string();
+  std::bitset<16> statusWordBits = this->iMotionCube.getStatusWord();
+  states.statusWord = statusWordBits.to_string();
+  std::bitset<16> detailedErrorBits = this->iMotionCube.getDetailedError();
+  states.detailedError = detailedErrorBits.to_string();
+  std::bitset<16> motionErrorBits = this->iMotionCube.getMotionError();
+  states.motionError = motionErrorBits.to_string();
 
-    states.state = this->iMotionCube.getState(this->iMotionCube.getStatusWord());
-    states.detailedErrorDescription = this->iMotionCube.parseDetailedError(this->iMotionCube.getDetailedError());
-    states.motionErrorDescription = this->iMotionCube.parseMotionError(this->iMotionCube.getMotionError());
+  states.state = this->iMotionCube.getState(this->iMotionCube.getStatusWord());
+  states.detailedErrorDescription = this->iMotionCube.parseDetailedError(this->iMotionCube.getDetailedError());
+  states.motionErrorDescription = this->iMotionCube.parseMotionError(this->iMotionCube.getMotionError());
 
-    states.motorCurrent = this->iMotionCube.getMotorCurrent();
-    states.motorVoltage = this->iMotionCube.getMotorVoltage();
+  states.motorCurrent = this->iMotionCube.getMotorCurrent();
+  states.motorVoltage = this->iMotionCube.getMotorVoltage();
 
-    return states;
+  return states;
 }
 
 void Joint::setName(const std::string& name)

--- a/march_hardware/test/TestIMotionCube.cpp
+++ b/march_hardware/test/TestIMotionCube.cpp
@@ -57,13 +57,38 @@ TEST_F(IMotionCubeTest, NoActuationMode)
   ASSERT_DEATH(imc.actuateRad(1), "trying to actuate rad, while actuationmode = unknown");
 }
 
-TEST_F(IMotionCubeTest, ChangeActuationMode)
+TEST_F(IMotionCubeTest, ActuationModeTorqueActuateRad)
+{
+    march4cpp::IMotionCube imc = march4cpp::IMotionCube(1, encoder);
+
+    imc.setActuationMode(march4cpp::ActuationMode("torque"));
+    ASSERT_DEATH(imc.actuateRad(1), "trying to actuate rad, while actuationmode = torque");
+}
+
+TEST_F(IMotionCubeTest, ActuationModePositionActuateTorque)
+{
+    march4cpp::IMotionCube imc = march4cpp::IMotionCube(1, encoder);
+
+    imc.setActuationMode(march4cpp::ActuationMode("position"));
+    ASSERT_DEATH(imc.actuateTorque(1), "trying to actuate torque, while actuationmode = position");
+}
+
+TEST_F(IMotionCubeTest, ChangeActuationModePosition)
 {
   march4cpp::IMotionCube imc = march4cpp::IMotionCube(1, encoder);
   ASSERT_EQ(march4cpp::ActuationMode::unknown, imc.getActuationMode().getValue());
 
   imc.setActuationMode(march4cpp::ActuationMode("position"));
   ASSERT_EQ(march4cpp::ActuationMode::position, imc.getActuationMode().getValue());
+}
+
+TEST_F(IMotionCubeTest, ChangeActuationModeTorque)
+{
+    march4cpp::IMotionCube imc = march4cpp::IMotionCube(1, encoder);
+    ASSERT_EQ(march4cpp::ActuationMode::unknown, imc.getActuationMode().getValue());
+
+    imc.setActuationMode(march4cpp::ActuationMode("torque"));
+    ASSERT_EQ(march4cpp::ActuationMode::torque, imc.getActuationMode().getValue());
 }
 
 TEST_F(IMotionCubeTest, ChangeActuationModeToUnknown)
@@ -75,4 +100,22 @@ TEST_F(IMotionCubeTest, ChangeActuationModeToUnknown)
   ASSERT_EQ(march4cpp::ActuationMode::position, imc.getActuationMode().getValue());
 
   ASSERT_THROW(imc.setActuationMode(march4cpp::ActuationMode("unknown")), std::runtime_error);
+}
+
+TEST_F(IMotionCubeTest, ChangeActuationModeFromPositionToTorque)
+{
+    march4cpp::IMotionCube imc = march4cpp::IMotionCube(1, encoder);
+    imc.setActuationMode(march4cpp::ActuationMode("position"));
+    ASSERT_EQ(march4cpp::ActuationMode::position, imc.getActuationMode().getValue());
+
+    ASSERT_THROW(imc.setActuationMode(march4cpp::ActuationMode("torque")), std::runtime_error);
+}
+
+TEST_F(IMotionCubeTest, ChangeActuationModeFromTorqueToPosition)
+{
+    march4cpp::IMotionCube imc = march4cpp::IMotionCube(1, encoder);
+    imc.setActuationMode(march4cpp::ActuationMode("torque"));
+    ASSERT_EQ(march4cpp::ActuationMode::torque, imc.getActuationMode().getValue());
+
+    ASSERT_THROW(imc.setActuationMode(march4cpp::ActuationMode("position")), std::runtime_error);
 }

--- a/march_hardware/test/TestJoint.cpp
+++ b/march_hardware/test/TestJoint.cpp
@@ -67,3 +67,29 @@ TEST_F(JointTest, ChangeActuationModeToUnknown)
 
   ASSERT_THROW(joint.setActuationMode(march4cpp::ActuationMode("unknown")), std::runtime_error);
 }
+
+TEST_F(JointTest, ChangeActuationModeFromPositionToTorque)
+{
+    march4cpp::Joint joint;
+
+    joint.setName("test_joint");
+    ASSERT_EQ(joint.getActuationMode().getValue(), march4cpp::ActuationMode::unknown);
+
+    joint.setActuationMode(march4cpp::ActuationMode("position"));
+    ASSERT_EQ(joint.getActuationMode().getValue(), march4cpp::ActuationMode::position);
+
+    ASSERT_THROW(joint.setActuationMode(march4cpp::ActuationMode("torque")), std::runtime_error);
+}
+
+TEST_F(JointTest, ChangeActuationModeFromTorqueToPosition)
+{
+    march4cpp::Joint joint;
+
+    joint.setName("test_joint");
+    ASSERT_EQ(joint.getActuationMode().getValue(), march4cpp::ActuationMode::unknown);
+
+    joint.setActuationMode(march4cpp::ActuationMode("torque"));
+    ASSERT_EQ(joint.getActuationMode().getValue(), march4cpp::ActuationMode::torque);
+
+    ASSERT_THROW(joint.setActuationMode(march4cpp::ActuationMode("position")), std::runtime_error);
+}


### PR DESCRIPTION
Also some style things are adjusted.

ActuateTorque method is added to iMotionCube and Joint. However it is not yet implemented in the march_hardware_interface. 
