### PR TITLE
Add after limit joint command publisher to march_hardware_interface

### DIFF
--- a/march_hardware_interface/include/march_hardware_interface/march_hardware_interface.h
+++ b/march_hardware_interface/include/march_hardware_interface/march_hardware_interface.h
@@ -6,6 +6,7 @@
 #include <ros/ros.h>
 #include <realtime_tools/realtime_publisher.h>
 #include <march_shared_resources/ImcErrorState.h>
+#include <march_shared_resources/AfterLimitJointCommand.h>
 #include <march_hardware_builder/HardwareBuilder.h>
 
 #include <march_hardware/MarchRobot.h>
@@ -16,7 +17,8 @@ using joint_limits_interface::SoftJointLimits;
 using joint_limits_interface::PositionJointSoftLimitsHandle;
 using joint_limits_interface::PositionJointSoftLimitsInterface;
 
-namespace march_hardware_interface {
+namespace march_hardware_interface
+{
 static const double POSITION_STEP_FACTOR = 10;
 static const double VELOCITY_STEP_FACTOR = 10;
 
@@ -25,9 +27,10 @@ static const double VELOCITY_STEP_FACTOR = 10;
  * @details Register an interface for each joint such that they can be actuated
  *     by a controller via ros_control.
  */
-class MarchHardwareInterface : public march_hardware_interface::MarchHardware {
+class MarchHardwareInterface : public march_hardware_interface::MarchHardware
+{
 public:
-  MarchHardwareInterface(ros::NodeHandle &nh, AllowedRobot robotName);
+  MarchHardwareInterface(ros::NodeHandle& nh, AllowedRobot robotName);
   ~MarchHardwareInterface();
 
   /**
@@ -35,7 +38,7 @@ public:
    * for each joint.
    */
   void init();
-  void update(const ros::TimerEvent &e);
+  void update(const ros::TimerEvent& e);
 
   /**
    * @brief Read actual postion from the hardware.
@@ -65,6 +68,9 @@ protected:
   bool hasPowerDistributionBoard = false;
   boost::shared_ptr<controller_manager::ControllerManager> controller_manager_;
   typedef boost::shared_ptr<realtime_tools::RealtimePublisher<march_shared_resources::ImcErrorState> > RtPublisherPtr;
+  typedef boost::shared_ptr<realtime_tools::RealtimePublisher<march_shared_resources::AfterLimitJointCommand> >
+      RtPublisherAfterLimitJointCommandPtr;
+  RtPublisherAfterLimitJointCommandPtr after_limit_joint_command_pub_;
   RtPublisherPtr imc_state_pub_;
   double p_error_, v_error_, e_error_;
   std::vector<SoftJointLimits> soft_limits_;
@@ -73,6 +79,7 @@ private:
   void updatePowerNet();
   void updateHighVoltageEnable();
   void updatePowerDistributionBoard();
+  void updateAfterLimitJointCommand();
   void updateIMotionCubeState();
   void resetIMotionCubesUntilTheyWork();
   void outsideLimitsCheck(int joint_index);

--- a/march_hardware_interface/include/march_hardware_interface/march_hardware_interface.h
+++ b/march_hardware_interface/include/march_hardware_interface/march_hardware_interface.h
@@ -30,7 +30,7 @@ static const double VELOCITY_STEP_FACTOR = 10;
 class MarchHardwareInterface : public march_hardware_interface::MarchHardware
 {
 public:
-  MarchHardwareInterface(ros::NodeHandle& nh, AllowedRobot robotName);
+  MarchHardwareInterface(ros::NodeHandle &nh, AllowedRobot robotName);
   ~MarchHardwareInterface();
 
   /**
@@ -38,7 +38,7 @@ public:
    * for each joint.
    */
   void init();
-  void update(const ros::TimerEvent& e);
+  void update(const ros::TimerEvent &e);
 
   /**
    * @brief Read actual postion from the hardware.

--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -382,7 +382,6 @@ void MarchHardwareInterface::updatePowerNet()
 
 void MarchHardwareInterface::updateAfterLimitJointCommand()
 {
-  return;
   if (!after_limit_joint_command_pub_->trylock())
   {
     return;

--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -41,6 +41,10 @@ void MarchHardwareInterface::init()
   imc_state_pub_ = RtPublisherPtr(
       new realtime_tools::RealtimePublisher<march_shared_resources::ImcErrorState>(this->nh_, "/march/imc_states/", 4));
 
+  after_limit_joint_command_pub_ = RtPublisherAfterLimitJointCommandPtr(
+      new realtime_tools::RealtimePublisher<march_shared_resources::AfterLimitJointCommand>(
+          this->nh_, "/march/controller/after_limit_joint_command/", 4));
+
   // Start ethercat cycle in the hardware
   this->marchRobot.startEtherCAT();
 
@@ -255,15 +259,19 @@ void MarchHardwareInterface::write(ros::Duration elapsed_time)
 
   for (int i = 0; i < num_joints_; i++)
   {
-    if (marchRobot.getJoint(joint_names_[i]).canActuate())
+    march4cpp::Joint joint = marchRobot.getJoint(joint_names_[i]);
+
+    if (joint.canActuate())
     {
       ROS_DEBUG("After limits: Trying to actuate joint %s, to %lf rad, %f "
                 "speed, %f effort.",
                 joint_names_[i].c_str(), joint_position_command_[i], joint_velocity_command_[i],
                 joint_effort_command_[i]);
-      marchRobot.getJoint(joint_names_[i]).actuateRad(static_cast<float>(joint_position_command_[i]));
+      joint.actuateRad(static_cast<float>(joint_position_command_[i]));
     }
   }
+
+  this->updateAfterLimitJointCommand();
 
   if (hasPowerDistributionBoard)
   {
@@ -370,6 +378,31 @@ void MarchHardwareInterface::updatePowerNet()
       power_net_on_off_command_.reset();
     }
   }
+}
+
+void MarchHardwareInterface::updateAfterLimitJointCommand()
+{
+  return;
+  if (!after_limit_joint_command_pub_->trylock())
+  {
+    return;
+  }
+
+  // Clear msg of AfterLimitJointCommand
+  after_limit_joint_command_pub_->msg_.name.clear();
+  after_limit_joint_command_pub_->msg_.position_command.clear();
+  after_limit_joint_command_pub_->msg_.effort_command.clear();
+
+  for (int i = 0; i < num_joints_; i++)
+  {
+    march4cpp::Joint singleJoint = marchRobot.getJoint(joint_names_[i]);
+
+    after_limit_joint_command_pub_->msg_.name.push_back(singleJoint.getName());
+    after_limit_joint_command_pub_->msg_.position_command.push_back(joint_position_command_[i]);
+    after_limit_joint_command_pub_->msg_.effort_command.push_back(joint_effort_command_[i]);
+  }
+
+  after_limit_joint_command_pub_->unlockAndPublish();
 }
 
 void MarchHardwareInterface::updateIMotionCubeState()

--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -394,9 +394,9 @@ void MarchHardwareInterface::updateAfterLimitJointCommand()
 
   for (int i = 0; i < num_joints_; i++)
   {
-    march4cpp::Joint singleJoint = marchRobot.getJoint(joint_names_[i]);
+    march4cpp::Joint joint = marchRobot.getJoint(joint_names_[i]);
 
-    after_limit_joint_command_pub_->msg_.name.push_back(singleJoint.getName());
+    after_limit_joint_command_pub_->msg_.name.push_back(joint.getName());
     after_limit_joint_command_pub_->msg_.position_command.push_back(joint_position_command_[i]);
     after_limit_joint_command_pub_->msg_.effort_command.push_back(joint_effort_command_[i]);
   }


### PR DESCRIPTION
The same pullrequest as https://github.com/project-march/hardware-interface/pull/116, but no unnecessary changes. 

- Still somehow some style things were adjusted. Also 

- This pullrequest publishes the commands after the limits and which commands actually are sent towards the IMC.

- A small refactor of the write method with the new joint.getname function
 
