### PR TITLE
Add actuationmode to march3 yaml

### DIFF
--- a/march_hardware_builder/src/robots/march3.yaml
+++ b/march_hardware_builder/src/robots/march3.yaml
@@ -7,64 +7,39 @@ march3:
         allowActuation: true
         imotioncube:
           slaveIndex: 8
-          encoder:
-            resolution: 16
-            minPositionIU: 22134
-            maxPositionIU: 43436
-            zeroPositionIU: 24515
-            safetyMarginRad: 0.05
+          encoder: {resolution: 16, minPositionIU: 22134, maxPositionIU: 43436, zeroPositionIU: 24515, safetyMarginRad: 0.05}
+
     - left_hip:
         actuationMode: position
         allowActuation: true
         imotioncube:
           slaveIndex: 3
-          encoder:
-            resolution: 16
-            minPositionIU: 9746
-            maxPositionIU: 31557
-            zeroPositionIU: 11830
-            safetyMarginRad: 0.05
+          encoder: {resolution: 16, minPositionIU: 9746, maxPositionIU: 31557, zeroPositionIU: 11830, safetyMarginRad: 0.05}
+
     - right_knee:
         actuationMode: position
         allowActuation: true
         imotioncube:
           slaveIndex: 10
-          encoder:
-            resolution: 16
-            minPositionIU: 18120
-            maxPositionIU: 39941
-            zeroPositionIU: 19000
-            safetyMarginRad: 0.05
+          encoder: {resolution: 16, minPositionIU: 18120, maxPositionIU: 39941, zeroPositionIU: 19000, safetyMarginRad: 0.05}
+
     - left_knee:
         actuationMode: position
         allowActuation: true
         imotioncube:
           slaveIndex: 5
-          encoder:
-            resolution: 16
-            minPositionIU: 21924
-            maxPositionIU: 43734
-            zeroPositionIU: 22552
-            safetyMarginRad: 0.05
+          encoder: {resolution: 16, minPositionIU: 21924, maxPositionIU: 43734, zeroPositionIU: 22552, safetyMarginRad: 0.05}
+
     - right_ankle:
         actuationMode: position
         allowActuation: true
         imotioncube:
           slaveIndex: 12
-          encoder:
-            resolution: 12
-            minPositionIU: 1086
-            maxPositionIU: 1490
-            zeroPositionIU: 1301
-            safetyMarginRad: 0.005
+          encoder: {resolution: 12, minPositionIU: 1086, maxPositionIU: 1490, zeroPositionIU: 1301, safetyMarginRad: 0.005}
+
     - left_ankle:
         actuationMode: position
         allowActuation: true
         imotioncube:
           slaveIndex: 7
-          encoder:
-            resolution: 12
-            minPositionIU: 631
-            maxPositionIU: 1022
-            zeroPositionIU: 918
-            safetyMarginRad: 0.005
+          encoder: {resolution: 12, minPositionIU: 631, maxPositionIU: 1022, zeroPositionIU: 918, safetyMarginRad: 0.005}

--- a/march_hardware_builder/src/robots/march3.yaml
+++ b/march_hardware_builder/src/robots/march3.yaml
@@ -3,6 +3,7 @@ march3:
   ecatCycleTime: 4
   joints:
     - right_hip:
+        actuationMode: position
         allowActuation: true
         imotioncube:
           slaveIndex: 8
@@ -13,6 +14,7 @@ march3:
             zeroPositionIU: 24515
             safetyMarginRad: 0.05
     - left_hip:
+        actuationMode: position
         allowActuation: true
         imotioncube:
           slaveIndex: 3
@@ -23,6 +25,7 @@ march3:
             zeroPositionIU: 11830
             safetyMarginRad: 0.05
     - right_knee:
+        actuationMode: position
         allowActuation: true
         imotioncube:
           slaveIndex: 10
@@ -33,6 +36,7 @@ march3:
             zeroPositionIU: 19000
             safetyMarginRad: 0.05
     - left_knee:
+        actuationMode: position
         allowActuation: true
         imotioncube:
           slaveIndex: 5
@@ -43,6 +47,7 @@ march3:
             zeroPositionIU: 22552
             safetyMarginRad: 0.05
     - right_ankle:
+        actuationMode: position
         allowActuation: true
         imotioncube:
           slaveIndex: 12
@@ -53,6 +58,7 @@ march3:
             zeroPositionIU: 1301
             safetyMarginRad: 0.005
     - left_ankle:
+        actuationMode: position
         allowActuation: true
         imotioncube:
           slaveIndex: 7

--- a/march_hardware_builder/test/TestAllowedRobots.cpp
+++ b/march_hardware_builder/test/TestAllowedRobots.cpp
@@ -44,26 +44,32 @@ TEST_F(AllowedRobotTest, TestMarch3Values)
   march4cpp::Joint leftHip;
   leftHip.setName("left_hip");
   leftHip.setIMotionCube(LHJimc);
+  leftHip.setActuationMode(march4cpp::ActuationMode("position"));
 
   march4cpp::Joint leftKnee;
   leftKnee.setName("left_knee");
   leftKnee.setIMotionCube(LKJimc);
+  leftKnee.setActuationMode(march4cpp::ActuationMode("position"));
 
   march4cpp::Joint leftAnkle;
   leftAnkle.setName("left_ankle");
   leftAnkle.setIMotionCube(LAJimc);
+  leftAnkle.setActuationMode(march4cpp::ActuationMode("position"));
 
   march4cpp::Joint rightHip;
   rightHip.setName("right_hip");
   rightHip.setIMotionCube(RHJimc);
+  rightHip.setActuationMode(march4cpp::ActuationMode("position"));
 
   march4cpp::Joint rightKnee;
   rightKnee.setName("right_knee");
   rightKnee.setIMotionCube(RKJimc);
+  rightKnee.setActuationMode(march4cpp::ActuationMode("position"));
 
   march4cpp::Joint rightAnkle;
   rightAnkle.setName("right_ankle");
   rightAnkle.setIMotionCube(RAJimc);
+  rightAnkle.setActuationMode(march4cpp::ActuationMode("position"));
 
   std::vector<march4cpp::Joint> jointList;
 


### PR DESCRIPTION
Actuationmode position is used with the march3. And the yaml has to reflect that.

- Add the actuationmode to march3 yaml

- Rearrange the march3 yaml encoder values

- Add actuationmode position to the march3value test