### PR TITLE
Add warn if wkc smaller than expected

### DIFF
--- a/march_hardware/src/EtherCAT/EthercatMaster.cpp
+++ b/march_hardware/src/EtherCAT/EthercatMaster.cpp
@@ -175,7 +175,12 @@ void EthercatMaster::sendProcessData()
 
 int EthercatMaster::receiveProcessData()
 {
-  return ec_receive_processdata(EC_TIMEOUTRET);
+  int wkc =  ec_receive_processdata(EC_TIMEOUTRET);
+  if (wkc < this->expectedWKC)
+  {
+    ROS_WARN("Working counter lower than expected. EtherCAT connection may not be optimal");
+  }
+  return wkc;
 }
 
 void EthercatMaster::monitorSlaveConnection()


### PR DESCRIPTION
Closes https://github.com/project-march/RunUpCybathlon2019/issues/79

Should be a stricter check on EtherCAT packages being lost. Recommended to use this by Arthur Ketels.

Still needs to be checked if the prints are useful. If not, this PR can be closed.