### PR TITLE
new endstop values lhaa lkfe

### DIFF
--- a/march_hardware_builder/robots/march4.yaml
+++ b/march_hardware_builder/robots/march4.yaml
@@ -18,7 +18,7 @@ march4:
         temperatureges: {slaveIndex: 7, byteOffset: 0}
         imotioncube:
           slaveIndex: 8
-          encoder: {resolution: 12, minPositionIU: 1010, maxPositionIU: 1401, zeroPositionIU: 1211, safetyMarginRad: 0.05}
+          encoder: {resolution: 12, minPositionIU: 1035, maxPositionIU: 1438, zeroPositionIU: 1242, safetyMarginRad: 0.05}
 
     - right_hip_fe:
         actuationMode: position
@@ -54,7 +54,7 @@ march4:
         temperatureges: {slaveIndex: 9, byteOffset: 4}
         imotioncube:
           slaveIndex: 10
-          encoder: {resolution: 17, minPositionIU: 19892, maxPositionIU: 63537, zeroPositionIU: 21711, safetyMarginRad: 0.05}
+          encoder: {resolution: 17, minPositionIU: 19808, maxPositionIU: 63543, zeroPositionIU: 21755, safetyMarginRad: 0.05}
 
     - right_ankle:
         actuationMode: position


### PR DESCRIPTION
<!--
No key provided
-->

Closes PM-

## Description
Recalibration for lkfe and lhaa. After the left leg has been taken apart, recalibration was needed to fix a discrepancy in the lhaa home stand position. During the fix another discrepancy was found in the lkfe. This pull request adjusts the min, max and zero positions of these joints in the march4.yaml file.


## Changes
adjusted the lhaa and lhfe min, max and zero positions in the march4.yaml


<!-- Please don't forget to request for reviews -->
