### PR TITLE
Revert ethercat_grant and add setcap

### DIFF
--- a/march_hardware/CMakeLists.txt
+++ b/march_hardware/CMakeLists.txt
@@ -85,8 +85,19 @@ install(TARGETS slave_count_check
     RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
+if($ENV{ETHERCAT_GRANT})
+    message("Granting raw ethernet port")
+    # Give sudo access to ethernet port
+    add_custom_command(
+        TARGET slave_count_check
+        COMMAND sudo setcap cap_net_raw+ep slave_count_check
+        WORKING_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_BIN_DESTINATION}
+        POST_BUILD
+    )
+endif()
+
 ## Add gtest based cpp test target and link libraries
-if (CATKIN_ENABLE_TESTING)
+if(CATKIN_ENABLE_TESTING)
     find_package(code_coverage REQUIRED)
     find_package(rostest REQUIRED)
 
@@ -124,4 +135,4 @@ if (CATKIN_ENABLE_TESTING)
             DEPENDS tests
         )
     endif()
-endif ()
+endif()

--- a/march_hardware_interface/CMakeLists.txt
+++ b/march_hardware_interface/CMakeLists.txt
@@ -69,8 +69,19 @@ install(DIRECTORY config launch
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
+if($ENV{ETHERCAT_GRANT})
+    message("Granting raw ethernet port")
+    # Give sudo access to ethernet port
+    add_custom_command(
+        TARGET ${PROJECT_NAME}_node
+        COMMAND sudo setcap cap_net_raw+ep ${PROJECT_NAME}_node
+        WORKING_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_BIN_DESTINATION}
+        POST_BUILD
+    )
+endif()
+
 ## Add gtest based cpp test target and link libraries
-if (CATKIN_ENABLE_TESTING)
+if(CATKIN_ENABLE_TESTING)
     find_package(code_coverage REQUIRED)
     find_package(rostest REQUIRED)
 
@@ -93,4 +104,4 @@ if (CATKIN_ENABLE_TESTING)
             DEPENDS tests
         )
     endif()
-endif ()
+endif()

--- a/march_hardware_interface/launch/march3_hardware.launch
+++ b/march_hardware_interface/launch/march3_hardware.launch
@@ -14,6 +14,6 @@
                 /march/controller/trajectory
             "/>
 
-    <node launch-prefix="ethercat_grant" name="march_hardware_interface" pkg="march_hardware_interface" type="march_hardware_interface_node" args="march3" output="screen"/>
+    <node name="march_hardware_interface" pkg="march_hardware_interface" type="march_hardware_interface_node" args="march3" output="screen"/>
 
 </launch>

--- a/march_hardware_interface/launch/march4.launch
+++ b/march_hardware_interface/launch/march4.launch
@@ -13,6 +13,6 @@
                 /march/controller/trajectory
             "/>
 
-    <node launch-prefix="ethercat_grant" name="march_hardware_interface" pkg="march_hardware_interface" type="march_hardware_interface_node" args="march4" output="screen"/>
+    <node name="march_hardware_interface" pkg="march_hardware_interface" type="march_hardware_interface_node" args="march4" output="screen"/>
 
 </launch>

--- a/march_hardware_interface/launch/march4.launch
+++ b/march_hardware_interface/launch/march4.launch
@@ -14,5 +14,4 @@
             "/>
 
     <node name="march_hardware_interface" pkg="march_hardware_interface" type="march_hardware_interface_node" args="march4" output="screen"/>
-
 </launch>

--- a/march_hardware_interface/launch/pdb.launch
+++ b/march_hardware_interface/launch/pdb.launch
@@ -6,6 +6,6 @@
                 /march/controller/pdb_state
             "/>
 
-    <node launch-prefix="ethercat_grant" name="march_hardware_interface" pkg="march_hardware_interface" type="march_hardware_interface_node" args="pdb" output="screen"/>
+    <node name="march_hardware_interface" pkg="march_hardware_interface" type="march_hardware_interface_node" args="pdb" output="screen"/>
 
 </launch>

--- a/march_hardware_interface/launch/testjoint_linear.launch
+++ b/march_hardware_interface/launch/testjoint_linear.launch
@@ -22,6 +22,6 @@
                 /march/controller/trajectory
             "/>
 
-    <node launch-prefix="ethercat_grant" name="march_hardware_interface" pkg="march_hardware_interface" type="march_hardware_interface_node" args="testjoint_linear" output="screen"/>
+    <node name="march_hardware_interface" pkg="march_hardware_interface" type="march_hardware_interface_node" args="testjoint_linear" output="screen"/>
 
 </launch>

--- a/march_hardware_interface/launch/testjoint_rotational.launch
+++ b/march_hardware_interface/launch/testjoint_rotational.launch
@@ -12,6 +12,6 @@
                 /march/controller/trajectory
             "/>
 
-    <node launch-prefix="ethercat_grant" name="march_hardware_interface" pkg="march_hardware_interface" type="march_hardware_interface_node" args="testjoint_rotational" output="screen"/>
+    <node name="march_hardware_interface" pkg="march_hardware_interface" type="march_hardware_interface_node" args="testjoint_rotational" output="screen"/>
 
 </launch>


### PR DESCRIPTION

## Description
This PR reverts the `ethercat_grant` launch prefix, since the executable was not able to dynamically link the libraries. See https://github.com/shadow-robot/ethercat_grant/issues/4. Therefore I reverted this change and added an `if()` statement that will only grant the raw ethernet ports permission if the environment variable `ETHERCAT_GRANT` is set to `1`. So the exoskeleton will have 

    export ETHERCAT_GRANT=1

added to its `.bashrc`. Furthermore the exoskeleton will have sudo privileges for the `setcap` utitlity, so that it does not require a password. You probably don't want to set this variable on your development machine, otherwise you have to type in your password :computer: 

## Changes
* remove `launch-prefix="ethercat_grant"`
* Added `setcap` command post build when `ETHERCAT_GRANT` is set to `1`
<!-- Please don't forget to request for reviews -->
