### PR TITLE
Fix/log fatal

### DIFF
--- a/march_hardware/src/EtherCAT/EthercatMaster.cpp
+++ b/march_hardware/src/EtherCAT/EthercatMaster.cpp
@@ -197,7 +197,7 @@ void EthercatMaster::monitorSlaveConnection()
     if (!ec_slave[slave].state)
     {
       // TODO(@Tim, @Isha, @Martijn) throw error when it happens multiple times in a short period of time.
-      ROS_WARN("EtherCAT train lost connection from slave %d onwards", slave);
+      ROS_WARN_THROTTLE(1, "EtherCAT train lost connection from slave %d onwards", slave);
       return;
     }
   }

--- a/march_hardware/src/IMotionCube.cpp
+++ b/march_hardware/src/IMotionCube.cpp
@@ -468,7 +468,7 @@ bool IMotionCube::goToTargetState(IMotionCubeTargetState targetState)
   while (!targetState.isReached(this->getStatusWord()))
   {
     this->setControlWord(targetState.getControlWord());
-    ROS_INFO_DELAYED_THROTTLE(2, "\tWaiting for '%s': %s", targetState.getDescription().c_str(),
+    ROS_INFO_DELAYED_THROTTLE(5, "\tWaiting for '%s': %s", targetState.getDescription().c_str(),
                               std::bitset<16>(this->getStatusWord()).to_string().c_str());
     if (targetState.getState() == IMotionCubeTargetState::OPERATION_ENABLED.getState() &&
         this->getState(this->getStatusWord()) == IMCState::fault)

--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -502,7 +502,7 @@ void MarchHardwareInterface::iMotionCubeStateCheck(int joint_index)
       errorStream << "Motion Error: " << iMotionCubeState.motionErrorDescription << "(" << iMotionCubeState.motionError
                   << ")" << std::endl;
 
-      ROS_FATAL_STREAM(errorStream);
+      ROS_FATAL("%s", errorStream.str().c_str());
       throw std::runtime_error(errorStream.str());
     }
   }
@@ -524,7 +524,7 @@ void MarchHardwareInterface::outsideLimitsCheck(int joint_index)
       errorStream << "Joint " << joint_names_[joint_index].c_str() << " is out of its soft limits ("
                   << soft_limits_[joint_index].min_position << ", " << soft_limits_[joint_index].max_position
                   << "). Actual position: " << joint_position_[joint_index];
-      ROS_FATAL_STREAM(errorStream);
+      ROS_FATAL("%s", errorStream.str().c_str());
       throw ::std::runtime_error(errorStream.str());
     }
   }

--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -217,6 +217,7 @@ void MarchHardwareInterface::init()
       joint.prepareActuation();
     }
   }
+  ROS_INFO("Successfully actuated all joints");
 }
 
 void MarchHardwareInterface::update(const ros::TimerEvent& e)
@@ -501,6 +502,7 @@ void MarchHardwareInterface::iMotionCubeStateCheck(int joint_index)
       errorStream << "Motion Error: " << iMotionCubeState.motionErrorDescription << "(" << iMotionCubeState.motionError
                   << ")" << std::endl;
 
+      ROS_FATAL_STREAM(errorStream);
       throw std::runtime_error(errorStream.str());
     }
   }
@@ -512,16 +514,17 @@ void MarchHardwareInterface::outsideLimitsCheck(int joint_index)
   if (joint_position_[joint_index] < soft_limits_[joint_index].min_position ||
       joint_position_[joint_index] > soft_limits_[joint_index].max_position)
   {
-    ROS_ERROR_THROTTLE(1, "Joint %s is outside of its soft_limits_ (%f, %f). Actual position: %f",
+    ROS_ERROR_THROTTLE(1, "Joint %s is outside of its soft limits (%f, %f). Actual position: %f",
                        joint_names_[joint_index].c_str(), soft_limits_[joint_index].min_position,
                        soft_limits_[joint_index].max_position, joint_position_[joint_index]);
 
     if (joint.canActuate())
     {
       std::ostringstream errorStream;
-      errorStream << "Joint " << joint_names_[joint_index].c_str() << " is out of its soft_limits_ ("
+      errorStream << "Joint " << joint_names_[joint_index].c_str() << " is out of its soft limits ("
                   << soft_limits_[joint_index].min_position << ", " << soft_limits_[joint_index].max_position
                   << "). Actual position: " << joint_position_[joint_index];
+      ROS_FATAL_STREAM(errorStream);
       throw ::std::runtime_error(errorStream.str());
     }
   }


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

## Description
During the training I found that most IMotionCube errors were not logged using `ROS_FATAL` when they threw an exception. Whether they should throw an exception is for another time.

## Changes
* Add `ROS_FATAL` to `iMotionCubeStateCheck` and `outsideLimitsCheck`
* Add `ROS_INFO` when all joints have been actuated

<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->

<!-- Please don't forget to request for reviews -->
