### PR TITLE
Remove the ROS kinetic test from the hardware interface.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,6 @@ env:
 
 jobs:
   include:
-    - name: "Kinetic"
-      env: ROS_DISTRO=kinetic
     - name: "Melodic"
       env: ROS_DISTRO=melodic
     - name: "clang-format"


### PR DESCRIPTION

## Description
Exo is now working on ubuntu 18 and ROS melodic so it is no longer necessary to check the kinetic ROS_DISTRO.


## Changes
* Removed the ROS kinetic check from the travis.yml  
