### PR TITLE
Fix: pdo map register

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ env:
     - BUILDER=colcon
     - CATKIN_LINT=pedantic
     - CATKIN_LINT_ARGS='--ignore literal_project_name --ignore target_name_collision'
-    - UPSTREAM_WORKSPACE='.rosinstall -march/march_data_collector -march/march_gait_scheduler -march/march_gain_scheduling -march/march_gait_selection -march/march_launch -march/march_safety -march/march_sound_scheduler -march/march_state_machine'
+    - UPSTREAM_WORKSPACE='.rosinstall -march/march_data_collector -march/march_gait_scheduler -march/march_gain_scheduling -march/march_gait_selection -march/march_launch -march/march_safety -march/march_state_machine'
 
 jobs:
   include:

--- a/march_hardware/include/march_hardware/IMotionCube.h
+++ b/march_hardware/include/march_hardware/IMotionCube.h
@@ -3,7 +3,7 @@
 #ifndef MARCH_HARDWARE_IMOTIONCUBE_H
 #define MARCH_HARDWARE_IMOTIONCUBE_H
 
-#include <map>
+#include <unordered_map>
 #include <string>
 
 #include <march_hardware/ActuationMode.h>
@@ -24,8 +24,8 @@ private:
 
   void actuateIU(int iu);
 
-  std::map<IMCObjectName, int> misoByteOffsets;
-  std::map<IMCObjectName, int> mosiByteOffsets;
+  std::unordered_map<IMCObjectName, int> misoByteOffsets;
+  std::unordered_map<IMCObjectName, int> mosiByteOffsets;
   void mapMisoPDOs();
   void mapMosiPDOs();
   void validateMisoPDOs();

--- a/march_hardware/include/march_hardware/PDOmap.h
+++ b/march_hardware/include/march_hardware/PDOmap.h
@@ -5,7 +5,6 @@
 #include <string>
 #include <utility>
 #include <vector>
-#include <map>
 #include <unordered_map>
 
 #include <ros/ros.h>
@@ -64,7 +63,7 @@ public:
   /** Initiate all the entered IMC objects to prepare the PDO.*/
   void addObject(IMCObjectName object_name);
 
-  std::map<IMCObjectName, int> map(int slave_index, dataDirection direction);
+  std::unordered_map<IMCObjectName, int> map(int slave_index, dataDirection direction);
 
   static std::unordered_map<IMCObjectName, IMCObject> all_objects;
 
@@ -75,9 +74,9 @@ private:
 
   /** Configures the PDO in the IMC using the given base register address and sync manager address.
    * @return map of the IMC PDO object name in combination with the byte-offset in the PDO register */
-  std::map<IMCObjectName, int> configurePDO(int slave_index, int base_register, int base_sync_manager);
+  std::unordered_map<IMCObjectName, int> configurePDO(int slave_index, int base_register, int base_sync_manager);
 
-  std::map<IMCObjectName, IMCObject> PDO_objects;
+  std::unordered_map<IMCObjectName, IMCObject> PDO_objects;
 
   const int bits_per_register = 64;           // Maximum amount of bits that can be constructed in one PDO message.
   const int nr_of_regs = 4;                   // Amount of registers available.

--- a/march_hardware/src/PDOmap.cpp
+++ b/march_hardware/src/PDOmap.cpp
@@ -1,7 +1,6 @@
 // Copyright 2019 Project March.
 #include <march_hardware/PDOmap.h>
 
-
 namespace march
 {
 std::unordered_map<IMCObjectName, IMCObject> PDOmap::all_objects = {

--- a/march_hardware/src/PDOmap.cpp
+++ b/march_hardware/src/PDOmap.cpp
@@ -1,8 +1,6 @@
 // Copyright 2019 Project March.
 #include <march_hardware/PDOmap.h>
 
-#include <map>
-#include <utility>
 
 namespace march
 {
@@ -53,7 +51,7 @@ void PDOmap::addObject(IMCObjectName object_name)
   }
 }
 
-std::map<IMCObjectName, int> PDOmap::map(int slave_index, enum dataDirection direction)
+std::unordered_map<IMCObjectName, int> PDOmap::map(int slave_index, dataDirection direction)
 {
   if (direction == dataDirection::miso)
   {
@@ -69,28 +67,27 @@ std::map<IMCObjectName, int> PDOmap::map(int slave_index, enum dataDirection dir
   }
 }
 
-std::map<IMCObjectName, int> PDOmap::configurePDO(int slave_index, int base_register, int base_sync_manager)
+std::unordered_map<IMCObjectName, int> PDOmap::configurePDO(int slave_index, int base_register, int base_sync_manager)
 {
   int counter = 1;
   int current_register = base_register;
   int size_left = this->bits_per_register;
 
-  std::map<IMCObjectName, int> byte_offsets;
+  std::unordered_map<IMCObjectName, int> byte_offsets;
   std::vector<std::pair<IMCObjectName, IMCObject>> sorted_PDO_objects = this->sortPDOObjects();
 
   sdo_bit8(slave_index, current_register, 0, 0);
   for (const auto& nextObject : sorted_PDO_objects)
   {
-    size_left -= nextObject.second.length;
-    if (size_left < 0)
+    if (size_left - nextObject.second.length < 0)
     {
       // PDO is filled so it can be enabled again
       sdo_bit8(slave_index, current_register, 0, counter - 1);
 
       // Update the sync manager with the just configured PDO
       sdo_bit8(slave_index, base_sync_manager, 0, 0);
-      int currentPDONr = (current_register - base_register) + 1;
-      sdo_bit16(slave_index, base_sync_manager, currentPDONr, current_register);
+      int current_pdo_nr = (current_register - base_register) + 1;
+      sdo_bit16(slave_index, base_sync_manager, current_pdo_nr, current_register);
 
       // Move to the next PDO register by incrementing with one
       current_register++;
@@ -99,17 +96,18 @@ std::map<IMCObjectName, int> PDOmap::configurePDO(int slave_index, int base_regi
         ROS_ERROR("Amount of registers was overwritten, amount of parameters does not fit in the PDO messages.");
       }
 
-      size_left = this->bits_per_register - nextObject.second.length;
+      size_left = this->bits_per_register;
       counter = 1;
 
       sdo_bit8(slave_index, current_register, 0, 0);
     }
 
-    int byteOffset = (bits_per_register - (size_left + nextObject.second.length)) / 8;
-    byte_offsets[nextObject.first] = byteOffset;
+    int byte_offset = (current_register - base_register) * 8 + (bits_per_register - size_left) / 8;
+    byte_offsets[nextObject.first] = byte_offset;
 
     sdo_bit32(slave_index, current_register, counter, nextObject.second.combined_address);
     counter++;
+    size_left -= nextObject.second.length;
   }
 
   // Make sure the last PDO is activated

--- a/march_hardware/test/TestPDOmap.cpp
+++ b/march_hardware/test/TestPDOmap.cpp
@@ -16,7 +16,7 @@ TEST_F(PDOTest, sortPDOmap)
   march::PDOmap pdoMapMISO = march::PDOmap();
   pdoMapMISO.addObject(march::IMCObjectName::StatusWord);
   pdoMapMISO.addObject(march::IMCObjectName::ActualPosition);
-  std::map<march::IMCObjectName, int> misoByteOffsets = pdoMapMISO.map(1, march::dataDirection::miso);
+  std::unordered_map<march::IMCObjectName, int> misoByteOffsets = pdoMapMISO.map(1, march::dataDirection::miso);
 
   ASSERT_EQ(0, misoByteOffsets[march::IMCObjectName::ActualPosition]);
   ASSERT_EQ(4, misoByteOffsets[march::IMCObjectName::StatusWord]);
@@ -29,7 +29,7 @@ TEST_F(PDOTest, multipleAddObjects)
   pdoMapMISO.addObject(march::IMCObjectName::ActualPosition);
   pdoMapMISO.addObject(march::IMCObjectName::StatusWord);
   pdoMapMISO.addObject(march::IMCObjectName::StatusWord);
-  std::map<march::IMCObjectName, int> misoByteOffsets = pdoMapMISO.map(1, march::dataDirection::miso);
+  std::unordered_map<march::IMCObjectName, int> misoByteOffsets = pdoMapMISO.map(1, march::dataDirection::miso);
   ASSERT_EQ(2, misoByteOffsets.size());
 }
 
@@ -37,7 +37,7 @@ TEST_F(PDOTest, ObjectCounts)
 {
   march::PDOmap pdoMapMISO = march::PDOmap();
   pdoMapMISO.addObject(march::IMCObjectName::CurrentLimit);
-  std::map<march::IMCObjectName, int> misoByteOffsets = pdoMapMISO.map(1, march::dataDirection::miso);
+  std::unordered_map<march::IMCObjectName, int> misoByteOffsets = pdoMapMISO.map(1, march::dataDirection::miso);
   ASSERT_EQ(1, misoByteOffsets.count(march::IMCObjectName::CurrentLimit));
   ASSERT_EQ(0, misoByteOffsets.count(march::IMCObjectName::DCLinkVoltage));
 }


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

## Description
Fixes a bug introduced in #192 where the register offset was not added to the byte offset for registers higher than 0.

## Changes
* Added register offset to byte offset
* Changed PDO `map` to `unordered_map`

<!-- Please don't forget to request for reviews -->
