### PR TITLE
Feature: add coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ env:
     - DOCKER_RUN_OPTS='$CI_ENV'
     - TARGET_CMAKE_ARGS='-DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE_TESTING=ON'
     - UPSTREAM_WORKSPACE='.rosinstall -march/march_data_collector -march/march_gait_scheduler -march/march_gain_scheduling -march/march_gait_selection -march/march_launch -march/march_safety -march/march_state_machine'
-    - AFTER_RUN_TARGET_TEST='cd "$target_ws" && bash <(curl -s https://codecov.io/bash) -R src/hardware-interface -F test && bash <(curl -s https://codecov.io/bash) -R src/hardware-interface -F production'
+    - AFTER_RUN_TARGET_TEST='cd "$target_ws" && bash <(curl -s https://codecov.io/bash) -R src/hardware-interface -F test -f "!*lib*" -f "!*usr*" -f "!*ros*" && bash <(curl -s https://codecov.io/bash) -R src/hardware-interface -F production -f "!*lib*" -f "!*usr*" -f "!*ros*"'
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ git:
 env:
   global:
     - ROS_REPO=ros
+    - ADDITIONAL_DEBS=curl
     - CCACHE_DIR=$HOME/.ccache # enables C/C++ caching in industrial_ci
     - BUILDER=colcon
     - CATKIN_LINT=pedantic

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ env:
     - DOCKER_RUN_OPTS='$CI_ENV'
     - TARGET_CMAKE_ARGS='-DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE_TESTING=ON'
     - UPSTREAM_WORKSPACE='.rosinstall -march/march_data_collector -march/march_gait_scheduler -march/march_gain_scheduling -march/march_gait_selection -march/march_launch -march/march_safety -march/march_state_machine'
-    - AFTER_RUN_TARGET_TEST='cd "$target_ws" && bash <(curl -s https://codecov.io/bash) -R src/hardware-interface -F test -f "!*lib*" -f "!*usr*" -f "!*ros*" && bash <(curl -s https://codecov.io/bash) -R src/hardware-interface -F production -f "!*lib*" -f "!*usr*" -f "!*ros*"'
+    - AFTER_RUN_TARGET_TEST='cd "$target_ws" && bash <(curl -s https://codecov.io/bash) -R src/hardware-interface -F test && bash <(curl -s https://codecov.io/bash) -R src/hardware-interface -F production'
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,10 @@ env:
     - BUILDER=colcon
     - CATKIN_LINT=pedantic
     - CATKIN_LINT_ARGS='--ignore literal_project_name --ignore target_name_collision'
+    - CI_ENV=`bash <(curl -s https://codecov.io/env)`
+    - DOCKER_RUN_OPTS='$CI_ENV'
     - UPSTREAM_WORKSPACE='.rosinstall -march/march_data_collector -march/march_gait_scheduler -march/march_gain_scheduling -march/march_gait_selection -march/march_launch -march/march_safety -march/march_state_machine'
+    - AFTER_RUN_TARGET_TEST='cd "$target_ws" && builder_run_build "$target_ws/install" "$target_ws" --cmake-args -DENABLE_COVERAGE_TESTING=ON -DCMAKE_BUILD_TYPE=Debug --cmake-target coverage_report --cmake-target-skip-unavailable && bash <(curl -s https://codecov.io/bash)'
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ env:
     - DOCKER_RUN_OPTS='$CI_ENV'
     - TARGET_CMAKE_ARGS='-DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE_TESTING=ON'
     - UPSTREAM_WORKSPACE='.rosinstall -march/march_data_collector -march/march_gait_scheduler -march/march_gain_scheduling -march/march_gait_selection -march/march_launch -march/march_safety -march/march_state_machine'
-    - AFTER_RUN_TARGET_TEST='cd "$target_ws" && bash <(curl -s https://codecov.io/bash) -R src/hardware-interface'
+    - AFTER_RUN_TARGET_TEST='cd "$target_ws" && bash <(curl -s https://codecov.io/bash) -R src/hardware-interface -F test && bash <(curl -s https://codecov.io/bash) -R src/hardware-interface -F production'
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,9 @@ env:
     - CATKIN_LINT_ARGS='--ignore literal_project_name --ignore target_name_collision'
     - CI_ENV=`bash <(curl -s https://codecov.io/env)`
     - DOCKER_RUN_OPTS='$CI_ENV'
+    - TARGET_CMAKE_ARGS='-DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE_TESTING=ON'
     - UPSTREAM_WORKSPACE='.rosinstall -march/march_data_collector -march/march_gait_scheduler -march/march_gain_scheduling -march/march_gait_selection -march/march_launch -march/march_safety -march/march_state_machine'
-    - AFTER_RUN_TARGET_TEST='cd "$target_ws" && builder_run_build "$target_ws/install" "$target_ws" --cmake-args -DENABLE_COVERAGE_TESTING=ON -DCMAKE_BUILD_TYPE=Debug --cmake-target coverage_report --cmake-target-skip-unavailable && bash <(curl -s https://codecov.io/bash)'
+    - AFTER_RUN_TARGET_TEST='cd "$target_ws" && bash <(curl -s https://codecov.io/bash) -R src/hardware-interface'
 
 jobs:
   include:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 The hardware interface of the MARCH exoskeleton. This includes EtherCAT master and uses the SOEM library.
 
 ![GitHub release (latest by date including pre-releases)](https://img.shields.io/github/v/release/project-march/hardware-interface?include_prereleases)
+[![codecov](https://codecov.io/gh/project-march/hardware-interface/branch/develop/graph/badge.svg?flag=production)](https://codecov.io/gh/project-march/hardware-interface)
+
 
 | Branch | Build Status |
 | ------ |:------------:|

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,2 +1,9 @@
+ignore:
+  - "**/*/march_hardware/check/*"
+  - "**/*/march_hardware/test/*"
+  - "**/*/march_hardware_builder/test/*"
+  - "**/*/march_hardware_interface/test/*"
+  - "**/*/march_imu_manager/lib/*"
+  - "**/*/march_imu_manager/test/*"
 fixes:
   - "src/hardware-interface/::"

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,7 +1,2 @@
 fixes:
-  - "src/march_hardware/::"
-  - "src/march_hardware_builder/::"
-  - "src/march_hardware_interface/::"
-  - "src/march_imu_manager/::"
-  - "src/march_pdb_state_controller/::"
-  - "src/march_temperature_sensor_controller/::"
+  - "src/hardware-interface/::"

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,7 +1,7 @@
-ignore:
-  - "march_hardware/soem/.*"
-  - "march_hardware/test/.*"
-  - "march_hardware_builder/test/.*"
-  - "march_hardware_interface/test/.*"
-  - "march_temperature_sensor_controller/test/.*"
-  
+fixes:
+  - "src/march_hardware/::"
+  - "src/march_hardware_builder/::"
+  - "src/march_hardware_interface/::"
+  - "src/march_imu_manager/::"
+  - "src/march_pdb_state_controller/::"
+  - "src/march_temperature_sensor_controller/::"

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,9 +1,0 @@
-ignore:
-  - "**/*/march_hardware/check/*"
-  - "**/*/march_hardware/test/*"
-  - "**/*/march_hardware_builder/test/*"
-  - "**/*/march_hardware_interface/test/*"
-  - "**/*/march_imu_manager/lib/*"
-  - "**/*/march_imu_manager/test/*"
-fixes:
-  - "src/hardware-interface/::"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,17 @@
+coverage:
+  status:
+    project:
+      default: off
+      production:
+        target: auto
+        flags:
+          - production
 fixes:
   - "src/hardware-interface/::"
+flags:
+  production:
+    paths:
+      - "*/src/**/*"
+  test:
+    paths:
+      - "*/test/**/*"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+fixes:
+  - "src/hardware-interface/::"

--- a/codecov.yml
+++ b/codecov.yml
@@ -12,6 +12,8 @@ flags:
   production:
     paths:
       - "*/src/**/*"
+      - "*/src/*"
   test:
     paths:
       - "*/test/**/*"
+      - "*/test/*"

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,6 +13,8 @@ flags:
     paths:
       - "*/src/**/*"
       - "*/src/*"
+      - "*/include/march_*/*"
+      - "*/include/march_*/**/*"
   test:
     paths:
       - "*/test/**/*"

--- a/march_hardware/CMakeLists.txt
+++ b/march_hardware/CMakeLists.txt
@@ -88,7 +88,7 @@ if (CATKIN_ENABLE_TESTING)
     target_link_libraries(${PROJECT_NAME}-test ${catkin_LIBRARIES} ${PROJECT_NAME} gtest)
 
     if(ENABLE_COVERAGE_TESTING)
-        set(COVERAGE_EXCLUDES "*/${PROJECT_NAME}/test*" "*/${PROJECT_NAME}/check*")
+        set(COVERAGE_EXCLUDES "*/${PROJECT_NAME}/test/*" "*/${PROJECT_NAME}/check/*")
         add_code_coverage(
             NAME coverage_report
             DEPENDENCIES ${PROJECT_NAME}-test

--- a/march_hardware/CMakeLists.txt
+++ b/march_hardware/CMakeLists.txt
@@ -24,7 +24,7 @@ include_directories(
 if(CATKIN_ENABLE_TESTING AND ENABLE_COVERAGE_TESTING)
     find_package(code_coverage REQUIRED)
     # Add compiler flags for coverage instrumentation before defining any targets
-    APPEND_COVERAGE_COMPILER_FLAGS()
+    append_coverage_compiler_flags()
 endif()
 
 add_library(${PROJECT_NAME}

--- a/march_hardware/CMakeLists.txt
+++ b/march_hardware/CMakeLists.txt
@@ -21,9 +21,11 @@ include_directories(
     ${soem_INCLUDE_DIRS}/soem
 )
 
-install(DIRECTORY include/${PROJECT_NAME}/
-    DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-)
+if(CATKIN_ENABLE_TESTING AND ENABLE_COVERAGE_TESTING)
+    find_package(code_coverage REQUIRED)
+    # Add compiler flags for coverage instrumentation before defining any targets
+    APPEND_COVERAGE_COMPILER_FLAGS()
+endif()
 
 add_library(${PROJECT_NAME}
     src/Encoder.cpp
@@ -46,6 +48,10 @@ target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 add_executable(slave_count_check check/SlaveCount.cpp)
 target_link_libraries(slave_count_check ${PROJECT_NAME})
 
+install(DIRECTORY include/${PROJECT_NAME}/
+    DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
+
 install(TARGETS ${PROJECT_NAME}
     ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
     LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
@@ -57,13 +63,7 @@ install(TARGETS slave_count_check
 
 ## Add gtest based cpp test target and link libraries
 if (CATKIN_ENABLE_TESTING)
-    find_package(code_coverage REQUIRED)
     find_package(rostest REQUIRED)
-
-    if(ENABLE_COVERAGE_TESTING)
-        include(CodeCoverage)
-        append_coverage_compiler_flags()
-    endif()
 
     add_rostest_gmock(${PROJECT_NAME}-test
         test/march_hardware.test
@@ -88,10 +88,10 @@ if (CATKIN_ENABLE_TESTING)
     target_link_libraries(${PROJECT_NAME}-test ${catkin_LIBRARIES} ${PROJECT_NAME} gtest)
 
     if(ENABLE_COVERAGE_TESTING)
-        set(COVERAGE_EXCLUDES "*/${PROJECT_NAME}/test*")
+        set(COVERAGE_EXCLUDES "*/${PROJECT_NAME}/test*" "*/${PROJECT_NAME}/check*")
         add_code_coverage(
-            NAME ${PROJECT_NAME}_coverage
-            DEPENDS tests
+            NAME coverage_report
+            DEPENDENCIES ${PROJECT_NAME}-test
         )
     endif()
 endif ()

--- a/march_hardware_builder/CMakeLists.txt
+++ b/march_hardware_builder/CMakeLists.txt
@@ -58,7 +58,7 @@ if (CATKIN_ENABLE_TESTING)
     target_link_libraries(${PROJECT_NAME}_test ${catkin_LIBRARIES} ${PROJECT_NAME} gtest gmock)
 
     if(ENABLE_COVERAGE_TESTING)
-        set(COVERAGE_EXCLUDES "*/${PROJECT_NAME}/test*")
+        set(COVERAGE_EXCLUDES "*/${PROJECT_NAME}/test/*")
         add_code_coverage(
             NAME coverage_report
             DEPENDENCIES ${PROJECT_NAME}_test

--- a/march_hardware_builder/CMakeLists.txt
+++ b/march_hardware_builder/CMakeLists.txt
@@ -15,6 +15,12 @@ catkin_package(
     LIBRARIES ${PROJECT_NAME}
 )
 
+if(CATKIN_ENABLE_TESTING AND ENABLE_COVERAGE_TESTING)
+    find_package(code_coverage REQUIRED)
+    # Add compiler flags for coverage instrumentation before defining any targets
+    APPEND_COVERAGE_COMPILER_FLAGS()
+endif()
+
 include_directories(include SYSTEM ${catkin_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME}
@@ -41,13 +47,6 @@ install(TARGETS ${PROJECT_NAME}
 
 ## Add gtest based cpp test target and link libraries
 if (CATKIN_ENABLE_TESTING)
-    find_package(code_coverage REQUIRED)
-
-    if(ENABLE_COVERAGE_TESTING)
-        include(CodeCoverage)
-        append_coverage_compiler_flags()
-    endif()
-
     catkin_add_gtest(${PROJECT_NAME}_test
         test/test_runner.cpp
         test/allowed_robot_test.cpp
@@ -61,8 +60,8 @@ if (CATKIN_ENABLE_TESTING)
     if(ENABLE_COVERAGE_TESTING)
         set(COVERAGE_EXCLUDES "*/${PROJECT_NAME}/test*")
         add_code_coverage(
-            NAME ${PROJECT_NAME}_coverage
-            DEPENDS tests
+            NAME coverage_report
+            DEPENDENCIES ${PROJECT_NAME}_test
         )
     endif()
 endif ()

--- a/march_hardware_builder/CMakeLists.txt
+++ b/march_hardware_builder/CMakeLists.txt
@@ -18,7 +18,7 @@ catkin_package(
 if(CATKIN_ENABLE_TESTING AND ENABLE_COVERAGE_TESTING)
     find_package(code_coverage REQUIRED)
     # Add compiler flags for coverage instrumentation before defining any targets
-    APPEND_COVERAGE_COMPILER_FLAGS()
+    append_coverage_compiler_flags()
 endif()
 
 include_directories(include SYSTEM ${catkin_INCLUDE_DIRS})

--- a/march_hardware_interface/CMakeLists.txt
+++ b/march_hardware_interface/CMakeLists.txt
@@ -38,6 +38,12 @@ catkin_package(
 
 include(cmake/${PROJECT_NAME}-extras.cmake)
 
+if(CATKIN_ENABLE_TESTING AND ENABLE_COVERAGE_TESTING)
+    find_package(code_coverage REQUIRED)
+    # Add compiler flags for coverage instrumentation before defining any targets
+    APPEND_COVERAGE_COMPILER_FLAGS()
+endif()
+
 include_directories(include SYSTEM ${catkin_INCLUDE_DIRS})
 
 # needed to circumvent LD_LIBRARY_PATH being emptied through ethercat_grant
@@ -69,26 +75,17 @@ install(DIRECTORY config launch
 
 ## Add gtest based cpp test target and link libraries
 if(CATKIN_ENABLE_TESTING)
-    find_package(code_coverage REQUIRED)
-    find_package(rostest REQUIRED)
-
-    if(ENABLE_COVERAGE_TESTING)
-        include(CodeCoverage)
-        append_coverage_compiler_flags()
-    endif()
-
-    add_rostest_gtest(${PROJECT_NAME}-test
-        test/${PROJECT_NAME}.test
+    catkin_add_gtest(${PROJECT_NAME}_test
         test/TestRunner.cpp
         test/TestPdbStateInterface.cpp
     )
-    target_link_libraries(${PROJECT_NAME}-test ${catkin_LIBRARIES} gtest gmock)
+    target_link_libraries(${PROJECT_NAME}_test ${catkin_LIBRARIES} gtest)
 
     if(ENABLE_COVERAGE_TESTING)
         set(COVERAGE_EXCLUDES "*/${PROJECT_NAME}/test*")
         add_code_coverage(
-            NAME ${PROJECT_NAME}_coverage
-            DEPENDS tests
+            NAME coverage_report
+            DEPENDENCIES ${PROJECT_NAME}_test
         )
     endif()
 endif()

--- a/march_hardware_interface/CMakeLists.txt
+++ b/march_hardware_interface/CMakeLists.txt
@@ -41,7 +41,7 @@ include(cmake/${PROJECT_NAME}-extras.cmake)
 if(CATKIN_ENABLE_TESTING AND ENABLE_COVERAGE_TESTING)
     find_package(code_coverage REQUIRED)
     # Add compiler flags for coverage instrumentation before defining any targets
-    APPEND_COVERAGE_COMPILER_FLAGS()
+    append_coverage_compiler_flags()
 endif()
 
 include_directories(include SYSTEM ${catkin_INCLUDE_DIRS})

--- a/march_hardware_interface/CMakeLists.txt
+++ b/march_hardware_interface/CMakeLists.txt
@@ -82,7 +82,7 @@ if(CATKIN_ENABLE_TESTING)
     target_link_libraries(${PROJECT_NAME}_test ${catkin_LIBRARIES} gtest)
 
     if(ENABLE_COVERAGE_TESTING)
-        set(COVERAGE_EXCLUDES "*/${PROJECT_NAME}/test*")
+        set(COVERAGE_EXCLUDES "*/${PROJECT_NAME}/test/*")
         add_code_coverage(
             NAME coverage_report
             DEPENDENCIES ${PROJECT_NAME}_test

--- a/march_hardware_interface/package.xml
+++ b/march_hardware_interface/package.xml
@@ -28,6 +28,6 @@
   <exec_depend>xacro</exec_depend>
   <exec_depend>ethercat_grant</exec_depend>
 
-  <test_depend>rostest</test_depend>
+  <test_depend>rosunit</test_depend>
   <test_depend>code_coverage</test_depend>
 </package>

--- a/march_hardware_interface/test/TestPdbStateInterface.cpp
+++ b/march_hardware_interface/test/TestPdbStateInterface.cpp
@@ -2,12 +2,7 @@
 
 #include "march_hardware_interface/march_pdb_state_interface.h"
 #include "gtest/gtest.h"
-#include <gmock/gmock.h>
 #include <sstream>
-
-using ::testing::AtLeast;
-using ::testing::AtMost;
-using ::testing::Return;
 
 class TestPdbStateInterface : public ::testing::Test
 {

--- a/march_hardware_interface/test/TestRunner.cpp
+++ b/march_hardware_interface/test/TestRunner.cpp
@@ -1,20 +1,9 @@
 // Copyright 2019 Project March.
 
-#include "gtest/gtest.h"
-#include <gmock/gmock.h>
-
-#include <march_hardware_interface/march_hardware.h>
-/**
- * Empty class to create coverage report
- */
-class TestDummy : public ::testing::Test
-{
-};
+#include <gtest/gtest.h>
 
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-  auto res = RUN_ALL_TESTS();
-  return res;
+  return RUN_ALL_TESTS();
 }

--- a/march_hardware_interface/test/march_hardware_interface.test
+++ b/march_hardware_interface/test/march_hardware_interface.test
@@ -1,3 +1,0 @@
-<launch>
-    <test test-name="march_hardware_interface_test" pkg="march_hardware_interface" type="march_hardware_interface-test"/>
-</launch>

--- a/march_imu_manager/CMakeLists.txt
+++ b/march_imu_manager/CMakeLists.txt
@@ -91,7 +91,7 @@ if(CATKIN_ENABLE_TESTING)
     )
 
     if(ENABLE_COVERAGE_TESTING)
-        set(COVERAGE_EXCLUDES "*/${PROJECT_NAME}/test*" "*/${PROJECT_NAME}/lib*")
+        set(COVERAGE_EXCLUDES "*/${PROJECT_NAME}/test/*" "*/${PROJECT_NAME}/lib/*")
         add_code_coverage(
             NAME coverage_report
             DEPENDENCIES wireless_master_test

--- a/march_imu_manager/CMakeLists.txt
+++ b/march_imu_manager/CMakeLists.txt
@@ -25,7 +25,7 @@ include_directories(
 if(CATKIN_ENABLE_TESTING AND ENABLE_COVERAGE_TESTING)
     find_package(code_coverage REQUIRED)
     # Add compiler flags for coverage instrumentation before defining any targets
-    APPEND_COVERAGE_COMPILER_FLAGS()
+    append_coverage_compiler_flags()
 endif()
 
 set(xsensdeviceapi_LOCATION ${PROJECT_SOURCE_DIR}/lib/libxsensdeviceapi.so)

--- a/march_imu_manager/CMakeLists.txt
+++ b/march_imu_manager/CMakeLists.txt
@@ -22,6 +22,12 @@ include_directories(
     ${catkin_INCLUDE_DIRS}
 )
 
+if(CATKIN_ENABLE_TESTING AND ENABLE_COVERAGE_TESTING)
+    find_package(code_coverage REQUIRED)
+    # Add compiler flags for coverage instrumentation before defining any targets
+    APPEND_COVERAGE_COMPILER_FLAGS()
+endif()
+
 set(xsensdeviceapi_LOCATION ${PROJECT_SOURCE_DIR}/lib/libxsensdeviceapi.so)
 set(xstypes_LOCATION ${PROJECT_SOURCE_DIR}/lib/libxstypes.so)
 
@@ -83,4 +89,12 @@ if(CATKIN_ENABLE_TESTING)
         ${xstypes_LIBRARY}
         ${catkin_LIBRARIES}
     )
+
+    if(ENABLE_COVERAGE_TESTING)
+        set(COVERAGE_EXCLUDES "*/${PROJECT_NAME}/test*" "*/${PROJECT_NAME}/lib*")
+        add_code_coverage(
+            NAME coverage_report
+            DEPENDENCIES wireless_master_test
+        )
+    endif()
 endif()

--- a/march_imu_manager/package.xml
+++ b/march_imu_manager/package.xml
@@ -14,4 +14,5 @@
   <depend>sensor_msgs</depend>
 
   <test_depend>rosunit</test_depend>
+  <test_depend>code_coverage</test_depend>
 </package>


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

Closes PM-79

## Description
This PR adds coverage reports uploading to [codecov.io](https://codecov.io/gh/project-march/hardware-interface/branch/feature%2FPM-79-add-coverage-report). The test coverage is also uploaded but under a different flag and is not reported in normal project statistics.

You can also generate these reports locally by running:

    $ colcon build --cmake-args -DENABLE_COVERAGE_TESTING=ON -DCMAKE_BUILD_TYPE=Debug --cmake-target coverage_report --cmake-target-skip-unavailable 

This will build all packages with coverage flags enabled, run tests and create coverage reports. If you want to find the generated report of a package you can go to `build/<package>/coverage_report` and open `index.html` with your browser.

![image](https://user-images.githubusercontent.com/23523462/73546242-302a6500-443d-11ea-9ed1-fa864ae2059f.png)


## Changes
* Enable building with coverage enabled on Travis
* Add codecov uploading scripts to Travis
* Fix usage of `code_coverage` package, so that you get no more errors saying that the build is optimized, which is not good for coverage.

<!-- Please don't forget to request for reviews -->
