### PR TITLE
Fix random high effort peaks bug

### DIFF
--- a/march_hardware_interface/include/march_hardware_interface/march_hardware.h
+++ b/march_hardware_interface/include/march_hardware_interface/march_hardware.h
@@ -53,7 +53,6 @@ protected:
   std::vector<double> joint_position_command_;
   std::vector<double> joint_velocity_command_;
   std::vector<double> joint_effort_command_;
-  std::vector<double> joint_effort_command_copy;
 
   march::PowerDistributionBoard power_distribution_board_read_;
   bool master_shutdown_allowed_command = false;

--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -265,7 +265,7 @@ void MarchHardwareInterface::write(const ros::Duration& elapsed_time)
 {
   for (int i = 0; i < num_joints_; i++)
   {
-    // Enlarge joint_effort_command so dynamic reconfigure can be used inside it's bounds
+    // Enlarge joint_effort_command because ROS control limits the pid values to a certain maximum
     joint_effort_command_[i] = joint_effort_command_[i] * 1000;
   }
   joint_effort_command_copy.clear();

--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -263,23 +263,20 @@ void MarchHardwareInterface::read(const ros::Duration& elapsed_time)
 
 void MarchHardwareInterface::write(const ros::Duration& elapsed_time)
 {
-  if (joint.getActuationMode() == march::ActuationMode::position)
+  for (int i = 0; i < num_joints_; i++)
   {
-    positionJointSoftLimitsInterface.enforceLimits(elapsed_time);
+    // Enlarge joint_effort_command so dynamic reconfigure can be used inside it's bounds
+    joint_effort_command_[i] = joint_effort_command_[i] * 1000;
   }
-  else if (joint.getActuationMode() == march::ActuationMode::torque)
-  {
-    for (int i = 0; i < num_joints_; i++)
-    {
-      // Enlarge joint_effort_command so dynamic reconfigure can be used inside it's bounds
-      joint_effort_command_[i] = joint_effort_command_[i] * 1000;
-    }
-    joint_effort_command_copy.clear();
-    joint_effort_command_copy.resize(joint_effort_command_.size());
-    joint_effort_command_copy = joint_effort_command_;
+  joint_effort_command_copy.clear();
+  joint_effort_command_copy.resize(joint_effort_command_.size());
+  joint_effort_command_copy = joint_effort_command_;
 
-    effortJointSoftLimitsInterface.enforceLimits(elapsed_time);
-  }
+  // Enforce limits on all joints in effort mode
+  effortJointSoftLimitsInterface.enforceLimits(elapsed_time);
+
+  // Enforce limits on all joints in position mode
+  positionJointSoftLimitsInterface.enforceLimits(elapsed_time);
 
   for (int i = 0; i < num_joints_; i++)
   {

--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -268,9 +268,6 @@ void MarchHardwareInterface::write(const ros::Duration& elapsed_time)
     // Enlarge joint_effort_command because ROS control limits the pid values to a certain maximum
     joint_effort_command_[i] = joint_effort_command_[i] * 1000;
   }
-  joint_effort_command_copy.clear();
-  joint_effort_command_copy.resize(joint_effort_command_.size());
-  joint_effort_command_copy = joint_effort_command_;
 
   // Enforce limits on all joints in effort mode
   effortJointSoftLimitsInterface.enforceLimits(elapsed_time);
@@ -288,14 +285,6 @@ void MarchHardwareInterface::write(const ros::Duration& elapsed_time)
                 "speed, %f effort.",
                 joint_names_[i].c_str(), joint_position_command_[i], joint_velocity_command_[i],
                 joint_effort_command_[i]);
-
-      if (joint_effort_command_[i] != joint_effort_command_copy[i])
-      {
-        ROS_WARN("Effort command (%f) changed to random high number (%f) for joint(%s), "
-                 "but set back to the normal value.",
-                 joint_effort_command_copy[i], joint_effort_command_[i], joint_names_[i].c_str());
-        joint_effort_command_[i] = joint_effort_command_copy[i];
-      }
 
       if (joint.getActuationMode() == march::ActuationMode::position)
       {


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->
## Description

Fix for the bug that the effort sometimes gets set to a very high value. 

The problem was the following:
There was a loop over all joints that first multiplies the effort of joint i by 1000, then enforces limits **on all joints** and then sends the effort joint i to the IMC. Hence, the effort limit got enforced on joints where the effort was not yet multiplied by 1000. The problem is that sometimes the minimum effort is nonzero, when the joint gets close to its limits. Then the effort limit thinks "hey the minimum effort is 1500 and it is only 4 so imma set it to 1500.", then when the loop get to this joint, the effort is multiplied by 1000 for a total of 1500000, which then gets enforced back to its max limit again by the effort limits enfocer.

Fixed by first multiplying all joint efforts by 1000 then enforcing limits on all joints only once.

<!--
Provide a concise description on the feature/fix your pull request implements.
-->
