### PR TITLE
Fix segmentation fault when launching

### DIFF
--- a/march_hardware/include/march_hardware/EtherCAT/EthercatMaster.h
+++ b/march_hardware/include/march_hardware/EtherCAT/EthercatMaster.h
@@ -24,7 +24,6 @@ class EthercatMaster
   int expectedWKC;
 
   std::thread EcatThread;
-  std::vector<Joint>* jointListPtr;
 
   int maxSlaveIndex;
   int ecatCycleTimems;
@@ -32,7 +31,7 @@ class EthercatMaster
 public:
   bool isOperational = false;
 
-  explicit EthercatMaster(std::vector<Joint>* jointListPtr, std::string ifname, int maxSlaveIndex, int ecatCycleTime);
+  explicit EthercatMaster(std::string ifname, int maxSlaveIndex, int ecatCycleTime);
   ~EthercatMaster();
 
   /* Delete copy constructor/assignment since the member thread can not be copied */
@@ -43,9 +42,9 @@ public:
   EthercatMaster(EthercatMaster&&) = default;
   EthercatMaster& operator=(EthercatMaster&&) = default;
 
-  void start();
+  void start(std::vector<Joint>& joints);
   void ethercatMasterInitiation();
-  void ethercatSlaveInitiation();
+  void ethercatSlaveInitiation(std::vector<Joint>& joints);
 
   void ethercatLoop();
   void SendReceivePDO();

--- a/march_hardware/include/march_hardware/EtherCAT/EthercatMaster.h
+++ b/march_hardware/include/march_hardware/EtherCAT/EthercatMaster.h
@@ -35,6 +35,10 @@ public:
   explicit EthercatMaster(std::vector<Joint>* jointListPtr, std::string ifname, int maxSlaveIndex, int ecatCycleTime);
   ~EthercatMaster();
 
+  EthercatMaster(const EthercatMaster&) = delete;
+  EthercatMaster& operator=(const EthercatMaster&) = delete;
+  EthercatMaster(EthercatMaster&&) = default;
+
   void start();
   void ethercatMasterInitiation();
   void ethercatSlaveInitiation();

--- a/march_hardware/include/march_hardware/EtherCAT/EthercatMaster.h
+++ b/march_hardware/include/march_hardware/EtherCAT/EthercatMaster.h
@@ -35,9 +35,13 @@ public:
   explicit EthercatMaster(std::vector<Joint>* jointListPtr, std::string ifname, int maxSlaveIndex, int ecatCycleTime);
   ~EthercatMaster();
 
+  /* Delete copy constructor/assignment since the member thread can not be copied */
   EthercatMaster(const EthercatMaster&) = delete;
   EthercatMaster& operator=(const EthercatMaster&) = delete;
+
+  /* Enable the move constructor and assignment */
   EthercatMaster(EthercatMaster&&) = default;
+  EthercatMaster& operator=(EthercatMaster&&) = default;
 
   void start();
   void ethercatMasterInitiation();

--- a/march_hardware/include/march_hardware/MarchRobot.h
+++ b/march_hardware/include/march_hardware/MarchRobot.h
@@ -17,9 +17,9 @@ namespace march
 class MarchRobot
 {
 private:
+  ::std::vector<Joint> jointList;
   EthercatMaster ethercatMaster;
   PowerDistributionBoard powerDistributionBoard;
-  ::std::vector<Joint> jointList;
 
 public:
   MarchRobot(::std::vector<Joint> jointList, ::std::string ifName, int ecatCycleTime);

--- a/march_hardware/include/march_hardware/MarchRobot.h
+++ b/march_hardware/include/march_hardware/MarchRobot.h
@@ -17,8 +17,8 @@ namespace march
 class MarchRobot
 {
 private:
-  std::unique_ptr<EthercatMaster> ethercatMaster;
-  std::unique_ptr<PowerDistributionBoard> powerDistributionBoard;
+  EthercatMaster ethercatMaster;
+  PowerDistributionBoard powerDistributionBoard;
   ::std::vector<Joint> jointList;
 
 public:
@@ -27,10 +27,12 @@ public:
   MarchRobot(::std::vector<Joint> jointList, PowerDistributionBoard powerDistributionBoard, ::std::string ifName,
              int ecatCycleTime);
 
-  // TODO(TIM) This is needed for the destructor, but why??
-  MarchRobot(MarchRobot&&) = default;
-
   ~MarchRobot();
+
+  MarchRobot(const MarchRobot&) = delete;
+  MarchRobot& operator=(const MarchRobot&) = delete;
+
+  MarchRobot(MarchRobot&&) = default;
 
   void startEtherCAT();
 
@@ -44,7 +46,8 @@ public:
 
   Joint getJoint(::std::string jointName);
 
-  const std::unique_ptr<PowerDistributionBoard>& getPowerDistributionBoard() const;
+  PowerDistributionBoard& getPowerDistributionBoard();
+  const PowerDistributionBoard& getPowerDistributionBoard() const;
 
   /** @brief Override comparison operator */
   friend bool operator==(const MarchRobot& lhs, const MarchRobot& rhs)

--- a/march_hardware/include/march_hardware/MarchRobot.h
+++ b/march_hardware/include/march_hardware/MarchRobot.h
@@ -29,10 +29,13 @@ public:
 
   ~MarchRobot();
 
+  /* Delete copy constructor/assignment since the ethercat master can not be copied */
   MarchRobot(const MarchRobot&) = delete;
   MarchRobot& operator=(const MarchRobot&) = delete;
 
+  /* Enable the move constructor and assignment */
   MarchRobot(MarchRobot&&) = default;
+  MarchRobot& operator=(MarchRobot&&) = default;
 
   void startEtherCAT();
 

--- a/march_hardware/src/EtherCAT/EthercatMaster.cpp
+++ b/march_hardware/src/EtherCAT/EthercatMaster.cpp
@@ -21,9 +21,7 @@
 
 namespace march
 {
-EthercatMaster::EthercatMaster(std::vector<Joint>* jointListPtr, std::string ifname, int maxSlaveIndex,
-                               int ecatCycleTime)
-  : jointListPtr(jointListPtr)
+EthercatMaster::EthercatMaster(std::string ifname, int maxSlaveIndex, int ecatCycleTime)
 {
   this->ifname = ifname;
   this->maxSlaveIndex = maxSlaveIndex;
@@ -38,10 +36,10 @@ EthercatMaster::~EthercatMaster()
 /**
  * Initiate the ethercat train and start the loop
  */
-void EthercatMaster::start()
+void EthercatMaster::start(std::vector<Joint>& joints)
 {
   EthercatMaster::ethercatMasterInitiation();
-  EthercatMaster::ethercatSlaveInitiation();
+  EthercatMaster::ethercatSlaveInitiation(joints);
 }
 
 /**
@@ -76,12 +74,12 @@ void EthercatMaster::ethercatMasterInitiation()
  * Set the found slaves to pre-operational state, configure the slaves and move to safe-operational state. If everything
  * went good move to operational state.
  */
-void EthercatMaster::ethercatSlaveInitiation()
+void EthercatMaster::ethercatSlaveInitiation(std::vector<Joint>& joints)
 {
   ROS_INFO("Request pre-operational state for all slaves");
   ec_statecheck(0, EC_STATE_PRE_OP, EC_TIMEOUTSTATE * 4);
 
-  for (auto& joint : *jointListPtr)
+  for (Joint& joint : joints)
   {
     joint.initialize(ecatCycleTimems);
   }

--- a/march_hardware/src/MarchRobot.cpp
+++ b/march_hardware/src/MarchRobot.cpp
@@ -24,9 +24,9 @@ MarchRobot::MarchRobot(::std::vector<Joint> jointList, ::std::string ifName, int
 
 MarchRobot::MarchRobot(::std::vector<Joint> jointList, PowerDistributionBoard powerDistributionBoard,
                        ::std::string ifName, int ecatCycleTime)
-    : jointList(std::move(jointList))
-    , powerDistributionBoard(powerDistributionBoard)
-    , ethercatMaster(EthercatMaster(&this->jointList, ifName, this->getMaxSlaveIndex(), ecatCycleTime))
+  : jointList(std::move(jointList))
+  , powerDistributionBoard(powerDistributionBoard)
+  , ethercatMaster(EthercatMaster(&this->jointList, ifName, this->getMaxSlaveIndex(), ecatCycleTime))
 {
 }
 

--- a/march_hardware/src/MarchRobot.cpp
+++ b/march_hardware/src/MarchRobot.cpp
@@ -17,8 +17,7 @@
 namespace march
 {
 MarchRobot::MarchRobot(::std::vector<Joint> jointList, ::std::string ifName, int ecatCycleTime)
-  : jointList(std::move(jointList))
-  , ethercatMaster(EthercatMaster(&this->jointList, ifName, this->getMaxSlaveIndex(), ecatCycleTime))
+  : jointList(std::move(jointList)), ethercatMaster(EthercatMaster(ifName, this->getMaxSlaveIndex(), ecatCycleTime))
 {
 }
 
@@ -26,7 +25,7 @@ MarchRobot::MarchRobot(::std::vector<Joint> jointList, PowerDistributionBoard po
                        ::std::string ifName, int ecatCycleTime)
   : jointList(std::move(jointList))
   , powerDistributionBoard(powerDistributionBoard)
-  , ethercatMaster(EthercatMaster(&this->jointList, ifName, this->getMaxSlaveIndex(), ecatCycleTime))
+  , ethercatMaster(EthercatMaster(ifName, this->getMaxSlaveIndex(), ecatCycleTime))
 {
 }
 
@@ -46,7 +45,7 @@ void MarchRobot::startEtherCAT()
     ROS_ERROR("Trying to start EtherCAT while it is already active.");
     return;
   }
-  ethercatMaster.start();
+  ethercatMaster.start(this->jointList);
 }
 
 void MarchRobot::stopEtherCAT()

--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -24,7 +24,7 @@ using march::Joint;
 
 MarchHardwareInterface::MarchHardwareInterface(march::MarchRobot robot)
   : march_robot_(std::move(robot))
-  , has_power_distribution_board_(march_robot_.getPowerDistributionBoard()->getSlaveIndex() != -1)
+  , has_power_distribution_board_(this->march_robot_.getPowerDistributionBoard().getSlaveIndex() != -1)
 {
 }
 
@@ -122,9 +122,9 @@ bool MarchHardwareInterface::init(ros::NodeHandle& nh, ros::NodeHandle& /* robot
         error_stream << "Joint " << joint_names_[i].c_str() << " has no net number";
         throw std::runtime_error(error_stream.str());
       }
-      while (!march_robot_.getPowerDistributionBoard()->getHighVoltage().getNetOperational(net_number))
+      while (!march_robot_.getPowerDistributionBoard().getHighVoltage().getNetOperational(net_number))
       {
-        march_robot_.getPowerDistributionBoard()->getHighVoltage().setNetOnOff(true, net_number);
+        march_robot_.getPowerDistributionBoard().getHighVoltage().setNetOnOff(true, net_number);
         usleep(100000);
         ROS_WARN("[%s] Waiting on high voltage", joint_names_[i].c_str());
       }
@@ -185,7 +185,7 @@ bool MarchHardwareInterface::init(ros::NodeHandle& nh, ros::NodeHandle& /* robot
         int net_number = joint.getNetNumber();
         if (net_number != -1)
         {
-          march_robot_.getPowerDistributionBoard()->getHighVoltage().setNetOnOff(true, net_number);
+          march_robot_.getPowerDistributionBoard().getHighVoltage().setNetOnOff(true, net_number);
         }
         else
         {
@@ -254,7 +254,7 @@ void MarchHardwareInterface::read(const ros::Time& /* time */, const ros::Durati
 
   if (has_power_distribution_board_)
   {
-    power_distribution_board_read_ = *march_robot_.getPowerDistributionBoard();
+    power_distribution_board_read_ = march_robot_.getPowerDistributionBoard();
 
     if (!power_distribution_board_read_.getHighVoltage().getHighVoltageEnabled())
     {
@@ -323,8 +323,8 @@ void MarchHardwareInterface::initiateIMC()
 
 void MarchHardwareInterface::updatePowerDistributionBoard()
 {
-  march_robot_.getPowerDistributionBoard()->setMasterOnline();
-  march_robot_.getPowerDistributionBoard()->setMasterShutDownAllowed(master_shutdown_allowed_command_);
+  march_robot_.getPowerDistributionBoard().setMasterOnline();
+  march_robot_.getPowerDistributionBoard().setMasterShutDownAllowed(master_shutdown_allowed_command_);
   updateHighVoltageEnable();
   updatePowerNet();
 }
@@ -333,12 +333,12 @@ void MarchHardwareInterface::updateHighVoltageEnable()
 {
   try
   {
-    if (march_robot_.getPowerDistributionBoard()->getHighVoltage().getHighVoltageEnabled() !=
+    if (march_robot_.getPowerDistributionBoard().getHighVoltage().getHighVoltageEnabled() !=
         enable_high_voltage_command_)
     {
-      march_robot_.getPowerDistributionBoard()->getHighVoltage().enableDisableHighVoltage(enable_high_voltage_command_);
+      march_robot_.getPowerDistributionBoard().getHighVoltage().enableDisableHighVoltage(enable_high_voltage_command_);
     }
-    else if (!march_robot_.getPowerDistributionBoard()->getHighVoltage().getHighVoltageEnabled())
+    else if (!march_robot_.getPowerDistributionBoard().getHighVoltage().getHighVoltageEnabled())
     {
       ROS_WARN_THROTTLE(2, "High voltage disabled");
     }
@@ -358,10 +358,10 @@ void MarchHardwareInterface::updatePowerNet()
   {
     try
     {
-      if (march_robot_.getPowerDistributionBoard()->getHighVoltage().getNetOperational(
+      if (march_robot_.getPowerDistributionBoard().getHighVoltage().getNetOperational(
               power_net_on_off_command_.getNetNumber()) != power_net_on_off_command_.isOnOrOff())
       {
-        march_robot_.getPowerDistributionBoard()->getHighVoltage().setNetOnOff(
+        march_robot_.getPowerDistributionBoard().getHighVoltage().setNetOnOff(
             power_net_on_off_command_.isOnOrOff(), power_net_on_off_command_.getNetNumber());
       }
     }
@@ -376,10 +376,10 @@ void MarchHardwareInterface::updatePowerNet()
   {
     try
     {
-      if (march_robot_.getPowerDistributionBoard()->getLowVoltage().getNetOperational(
+      if (march_robot_.getPowerDistributionBoard().getLowVoltage().getNetOperational(
               power_net_on_off_command_.getNetNumber()) != power_net_on_off_command_.isOnOrOff())
       {
-        march_robot_.getPowerDistributionBoard()->getLowVoltage().setNetOnOff(power_net_on_off_command_.isOnOrOff(),
+        march_robot_.getPowerDistributionBoard().getLowVoltage().setNetOnOff(power_net_on_off_command_.isOnOrOff(),
                                                                               power_net_on_off_command_.getNetNumber());
       }
     }

--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -361,8 +361,8 @@ void MarchHardwareInterface::updatePowerNet()
       if (march_robot_.getPowerDistributionBoard().getHighVoltage().getNetOperational(
               power_net_on_off_command_.getNetNumber()) != power_net_on_off_command_.isOnOrOff())
       {
-        march_robot_.getPowerDistributionBoard().getHighVoltage().setNetOnOff(
-            power_net_on_off_command_.isOnOrOff(), power_net_on_off_command_.getNetNumber());
+        march_robot_.getPowerDistributionBoard().getHighVoltage().setNetOnOff(power_net_on_off_command_.isOnOrOff(),
+                                                                              power_net_on_off_command_.getNetNumber());
       }
     }
     catch (std::exception& exception)
@@ -380,7 +380,7 @@ void MarchHardwareInterface::updatePowerNet()
               power_net_on_off_command_.getNetNumber()) != power_net_on_off_command_.isOnOrOff())
       {
         march_robot_.getPowerDistributionBoard().getLowVoltage().setNetOnOff(power_net_on_off_command_.isOnOrOff(),
-                                                                              power_net_on_off_command_.getNetNumber());
+                                                                             power_net_on_off_command_.getNetNumber());
       }
     }
     catch (std::exception& exception)


### PR DESCRIPTION

## Description
Fixed the issue where the hardware interface would have a segmentation fault on launch. 
In a last PR I changed the `MarchHardwareInterface` to accept a `MarchRobot` as parameter for its constructor. However, this meant the `MarchRobot` had to be moved. It cannot be copied because `EthercatMaster` has a `std::thread` which can not be copied.
However, the `MarchRobot` class used `unique_ptr`s for `EthercatMaster` and `PowerDistributionBoard`. A move would result in the `unique_ptr` being moved which would result in the original `unique_ptr` pointing to nothing. Then when the old `MarchRobot` was destructed it would try to access the moved ptr, which caused the segmentation fault.

I changed the `MarchRobot` to no longer use `unique_ptr` since there was no reason to.

## Changes
* Removed `unique_ptr`s in `MarchRobot`
* Explicitly removed copy constructor and assignments on `MarchRobot` and `EthercatMaster` to make it clear that these can not be used

<!-- Please don't forget to request for reviews -->
