### PR TITLE
Fix `what` implementation on HardwareException

### DIFF
--- a/march_hardware/test/error/test_hardware_exception.cpp
+++ b/march_hardware/test/error/test_hardware_exception.cpp
@@ -28,6 +28,18 @@ TEST(TestHardwareException, TestNoMessage)
   ASSERT_EQ(ss.str(), expected_ss.str());
 }
 
+TEST(TestHardwareException, TestWhat)
+{
+  ErrorType expected = ErrorType::UNKNOWN;
+  const std::string message = "test";
+  HardwareException exception(expected, message);
+
+  std::stringstream expected_ss;
+  expected_ss << expected << std::endl << message;
+
+  ASSERT_EQ(expected_ss.str(), std::string(exception.what()));
+}
+
 TEST(TestHardwareException, TestMessage)
 {
   ErrorType expected = ErrorType::UNKNOWN;

--- a/march_hardware_interface/src/march_hardware_interface_node.cpp
+++ b/march_hardware_interface/src/march_hardware_interface_node.cpp
@@ -34,14 +34,10 @@ int main(int argc, char** argv)
       return 1;
     }
   }
-  catch (const march::error::HardwareException& e)
-  {
-    ROS_FATAL_STREAM(e);
-    return 1;
-  }
   catch (const std::exception& e)
   {
-    ROS_FATAL("Hardware interface caught an exception during init: %s", e.what());
+    ROS_FATAL("Hardware interface caught an exception during init");
+    ROS_FATAL("%s", e.what());
     return 1;
   }
 
@@ -61,14 +57,10 @@ int main(int argc, char** argv)
       march.write(now, rate.expectedCycleTime());
       rate.sleep();
     }
-    catch (const march::error::HardwareException& e)
-    {
-      ROS_FATAL_STREAM(e);
-      return 1;
-    }
     catch (const std::exception& e)
     {
-      ROS_FATAL("Hardware interface caught an exception during update: %s", e.what());
+      ROS_FATAL("Hardware interface caught an exception during update");
+      ROS_FATAL("%s", e.what());
       return 1;
     }
   }


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

## Description
The implementation in `HardwareException` for `what()` was incorrectly implemented which gave no useful information when the exception occured during tests or other crashes.

## Changes
* Create `description` on construction of `HardwareException` and return it in `what()`
* Add test for `what()`
* Fix printing of error in hardware interface node

<!-- Please don't forget to request for reviews -->
