### PR TITLE
Fix all compiler warnings and turn them into errors

### DIFF
--- a/march_hardware/CMakeLists.txt
+++ b/march_hardware/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(march_hardware)
 
-add_compile_options(-std=c++14 -Wall -Wextra)
+add_compile_options(-std=c++14 -Wall -Wextra -Werror)
 
 find_package(catkin REQUIRED COMPONENTS
     roscpp

--- a/march_hardware/include/march_hardware/ActuationMode.h
+++ b/march_hardware/include/march_hardware/ActuationMode.h
@@ -48,13 +48,14 @@ public:
 
   uint8_t toModeNumber()
   {
-    if (this->value_ == position)
+    switch (this->value_)
     {
-      return 8;
-    }
-    else if (this->value_ == torque)
-    {
-      return 10;
+      case position:
+        return 8;
+      case torque:
+        return 10;
+      default:
+        return 0;
     }
   }
 

--- a/march_hardware/include/march_hardware/Slave.h
+++ b/march_hardware/include/march_hardware/Slave.h
@@ -26,7 +26,7 @@ public:
 
   ~Slave() = default;
 
-  virtual void writeInitialSDOs(int ecatCycleTime)
+  virtual void writeInitialSDOs(int /* cycle_time */)
   {
   }
 

--- a/march_hardware/src/EtherCAT/EthercatMaster.cpp
+++ b/march_hardware/src/EtherCAT/EthercatMaster.cpp
@@ -121,9 +121,9 @@ void EthercatMaster::ethercatSlaveInitiation(std::vector<Joint>& joints)
 
 void EthercatMaster::ethercatLoop()
 {
-  uint32_t totalLoops = 0;
-  uint32_t rateNotAchievedCount = 0;
-  int rate = 1000 / ecatCycleTimems;
+  size_t totalLoops = 0;
+  size_t rateNotAchievedCount = 0;
+  size_t rate = 1000 / ecatCycleTimems;
 
   while (isOperational)
   {

--- a/march_hardware/src/LowVoltage.cpp
+++ b/march_hardware/src/LowVoltage.cpp
@@ -36,7 +36,7 @@ bool LowVoltage::getNetOperational(int netNumber)
   return ((operational.ui >> (netNumber - 1)) & 1);
 }
 
-void LowVoltage::setNetOnOff(bool on, int netNumber)
+void LowVoltage::setNetOnOff(bool /* on */, int /* netNumber */)
 {
   ROS_ERROR_THROTTLE(2, "Can't control low voltage nets from master");
 }

--- a/march_hardware/src/MarchRobot.cpp
+++ b/march_hardware/src/MarchRobot.cpp
@@ -66,15 +66,15 @@ int MarchRobot::getMaxSlaveIndex()
 {
   int maxSlaveIndex = -1;
 
-  for (int i = 0; i < jointList.size(); i++)
+  for (Joint& joint : jointList)
   {
-    int temperatureSlaveIndex = jointList.at(i).getTemperatureGESSlaveIndex();
+    int temperatureSlaveIndex = joint.getTemperatureGESSlaveIndex();
     if (temperatureSlaveIndex > maxSlaveIndex)
     {
       maxSlaveIndex = temperatureSlaveIndex;
     }
 
-    int iMotionCubeSlaveIndex = jointList.at(i).getIMotionCubeSlaveIndex();
+    int iMotionCubeSlaveIndex = joint.getIMotionCubeSlaveIndex();
 
     if (iMotionCubeSlaveIndex > maxSlaveIndex)
     {
@@ -89,17 +89,17 @@ bool MarchRobot::hasValidSlaves()
   ::std::vector<int> iMotionCubeIndices;
   ::std::vector<int> temperatureSlaveIndices;
 
-  for (int i = 0; i < jointList.size(); i++)
+  for (auto& joint : jointList)
   {
-    if (jointList[i].hasTemperatureGES())
+    if (joint.hasTemperatureGES())
     {
-      int temperatureSlaveIndex = jointList[i].getTemperatureGESSlaveIndex();
+      int temperatureSlaveIndex = joint.getTemperatureGESSlaveIndex();
       temperatureSlaveIndices.push_back(temperatureSlaveIndex);
     }
 
-    if (jointList[i].hasIMotionCube())
+    if (joint.hasIMotionCube())
     {
-      int iMotionCubeSlaveIndex = jointList[i].getIMotionCubeSlaveIndex();
+      int iMotionCubeSlaveIndex = joint.getIMotionCubeSlaveIndex();
       iMotionCubeIndices.push_back(iMotionCubeSlaveIndex);
     }
   }
@@ -145,11 +145,11 @@ Joint MarchRobot::getJoint(::std::string jointName)
     ROS_WARN("Trying to access joints while ethercat is not operational. This "
              "may lead to incorrect sensor data.");
   }
-  for (int i = 0; i < jointList.size(); i++)
+  for (auto& joint : jointList)
   {
-    if (jointList.at(i).getName() == jointName)
+    if (joint.getName() == jointName)
     {
-      return jointList.at(i);
+      return joint;
     }
   }
 

--- a/march_hardware/src/PDOmap.cpp
+++ b/march_hardware/src/PDOmap.cpp
@@ -57,6 +57,9 @@ std::unordered_map<IMCObjectName, uint8_t> PDOmap::map(int slave_index, DataDire
       return configurePDO(slave_index, 0x1A00, 0x1C13);
     case DataDirection::MOSI:
       return configurePDO(slave_index, 0x1600, 0x1C12);
+    default:
+      ROS_ERROR("Invalid data direction given, returning empty map");
+      return {};
   }
 }
 

--- a/march_hardware/src/error/error_type.cpp
+++ b/march_hardware/src/error/error_type.cpp
@@ -33,7 +33,7 @@ const char* getErrorDescription(ErrorType type)
       return "Not all configured slaves were able to be found";
     case ErrorType::FAILED_TO_REACH_OPERATIONAL_STATE:
       return "At least one slave failed to reach ethercat operational state";
-    case ErrorType::UNKNOWN:
+    default:
       return "Unknown error occurred. Please create/use a documented error";
   }
 }

--- a/march_hardware/test/TestPDOmap.cpp
+++ b/march_hardware/test/TestPDOmap.cpp
@@ -18,8 +18,8 @@ TEST_F(PDOTest, sortPDOmap)
   pdoMapMISO.addObject(march::IMCObjectName::ActualPosition);
   std::unordered_map<march::IMCObjectName, uint8_t> misoByteOffsets = pdoMapMISO.map(1, march::DataDirection::MISO);
 
-  ASSERT_EQ(0, misoByteOffsets[march::IMCObjectName::ActualPosition]);
-  ASSERT_EQ(4, misoByteOffsets[march::IMCObjectName::StatusWord]);
+  ASSERT_EQ(0u, misoByteOffsets[march::IMCObjectName::ActualPosition]);
+  ASSERT_EQ(4u, misoByteOffsets[march::IMCObjectName::StatusWord]);
 }
 
 TEST_F(PDOTest, multipleAddObjects)
@@ -30,7 +30,7 @@ TEST_F(PDOTest, multipleAddObjects)
   pdoMapMISO.addObject(march::IMCObjectName::StatusWord);
   pdoMapMISO.addObject(march::IMCObjectName::StatusWord);
   std::unordered_map<march::IMCObjectName, uint8_t> misoByteOffsets = pdoMapMISO.map(1, march::DataDirection::MISO);
-  ASSERT_EQ(2, misoByteOffsets.size());
+  ASSERT_EQ(2u, misoByteOffsets.size());
 }
 
 TEST_F(PDOTest, ObjectCounts)
@@ -38,6 +38,6 @@ TEST_F(PDOTest, ObjectCounts)
   march::PDOmap pdoMapMISO = march::PDOmap();
   pdoMapMISO.addObject(march::IMCObjectName::CurrentLimit);
   std::unordered_map<march::IMCObjectName, uint8_t> misoByteOffsets = pdoMapMISO.map(1, march::DataDirection::MISO);
-  ASSERT_EQ(1, misoByteOffsets.count(march::IMCObjectName::CurrentLimit));
-  ASSERT_EQ(0, misoByteOffsets.count(march::IMCObjectName::DCLinkVoltage));
+  ASSERT_EQ(1u, misoByteOffsets.count(march::IMCObjectName::CurrentLimit));
+  ASSERT_EQ(0u, misoByteOffsets.count(march::IMCObjectName::DCLinkVoltage));
 }

--- a/march_hardware/test/TestPDOmap.cpp
+++ b/march_hardware/test/TestPDOmap.cpp
@@ -22,6 +22,13 @@ TEST_F(PDOTest, sortPDOmap)
   ASSERT_EQ(4u, misoByteOffsets[march::IMCObjectName::StatusWord]);
 }
 
+TEST_F(PDOTest, InvalidDataDirection)
+{
+  march::PDOmap map;
+  std::unordered_map<march::IMCObjectName, uint8_t> expected;
+  ASSERT_EQ(map.map(1, (march::DataDirection)7), expected);
+}
+
 TEST_F(PDOTest, multipleAddObjects)
 {
   march::PDOmap pdoMapMISO = march::PDOmap();

--- a/march_hardware/test/TestTemperatureGES.cpp
+++ b/march_hardware/test/TestTemperatureGES.cpp
@@ -46,7 +46,7 @@ TEST_F(TemperatureJointDeathTest, ByteOffsetMinusOne)
 
 TEST_F(TemperatureJointTest, NoSlaveIndexConstructor)
 {
-  ASSERT_NO_THROW(march::TemperatureGES tempSens = march::TemperatureGES());
+  ASSERT_NO_THROW(march::TemperatureGES());
 }
 TEST_F(TemperatureJointTest, NoSlaveIndexConstructorGetIndex)
 {

--- a/march_hardware_builder/CMakeLists.txt
+++ b/march_hardware_builder/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(march_hardware_builder)
 
-add_compile_options(-std=c++11 -Wall -Wextra)
+add_compile_options(-std=c++14 -Wall -Wextra -Werror)
 
 find_package(catkin REQUIRED COMPONENTS
     march_hardware

--- a/march_hardware_interface/CMakeLists.txt
+++ b/march_hardware_interface/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(march_hardware_interface)
 
-add_compile_options(-std=c++14 -Wall -Wextra)
+add_compile_options(-std=c++14 -Wall -Wextra -Werror)
 
 find_package(catkin REQUIRED COMPONENTS
     control_toolbox

--- a/march_imu_manager/CMakeLists.txt
+++ b/march_imu_manager/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(march_imu_manager)
 
-add_compile_options(-std=c++11 -Wall -Wextra)
+add_compile_options(-std=c++14 -Wall -Wextra -Werror)
 
 find_package(catkin REQUIRED COMPONENTS
     roscpp

--- a/march_pdb_state_controller/.gitignore
+++ b/march_pdb_state_controller/.gitignore
@@ -1,3 +1,0 @@
-bin
-build
-lib

--- a/march_pdb_state_controller/CMakeLists.txt
+++ b/march_pdb_state_controller/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(march_pdb_state_controller)
 
-add_compile_options(-std=c++11 -Wall -Wextra)
+add_compile_options(-std=c++14 -Wall -Wextra -Werror)
 
 find_package(catkin REQUIRED COMPONENTS
     controller_interface

--- a/march_pdb_state_controller/src/march_pdb_state_controller.cpp
+++ b/march_pdb_state_controller/src/march_pdb_state_controller.cpp
@@ -9,7 +9,7 @@ namespace march_pdb_state_controller
 // TODO(TIM) Remove the callbacks and subscribers when they are not needed anymore
 // These topics make it able to tests write to pdb commands.
 bool MarchPdbStateController::serviceDisableEnableHighVoltage(std_srvs::SetBool::Request& req,
-                                                              std_srvs::SetBool::Response& res)
+                                                              std_srvs::SetBool::Response& /* res */)
 {
   if (pdb_state_.getHighVoltageEnabled() != req.data)
   {

--- a/march_temperature_sensor_controller/.gitignore
+++ b/march_temperature_sensor_controller/.gitignore
@@ -1,3 +1,0 @@
-bin
-build
-lib

--- a/march_temperature_sensor_controller/CMakeLists.txt
+++ b/march_temperature_sensor_controller/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(march_temperature_sensor_controller)
 
-add_compile_options(-std=c++11 -Wall -Wextra)
+add_compile_options(-std=c++14 -Wall -Wextra -Werror)
 
 find_package(catkin REQUIRED COMPONENTS
     controller_interface


### PR DESCRIPTION
## Description
Finally, fixed those nasty compiler warnings :sweat_drops: 

## Changes
* Fixed compiler warnings
* Make all projects compile with c++14 standard
* Add `-Werror` which turns compiler warnings into errors

<!-- Please don't forget to request for reviews -->
