### PR TITLE
Remove reset imc

### DIFF
--- a/march_hardware/include/march_hardware/IMotionCube.h
+++ b/march_hardware/include/march_hardware/IMotionCube.h
@@ -44,7 +44,6 @@ public:
 
   void goToTargetState(IMotionCubeTargetState target_state);
   void goToOperationEnabled();
-  void resetIMotionCube();
 
   /** @brief Override comparison operator */
   friend bool operator==(const IMotionCube& lhs, const IMotionCube& rhs)

--- a/march_hardware/include/march_hardware/Joint.h
+++ b/march_hardware/include/march_hardware/Joint.h
@@ -29,8 +29,6 @@ public:
 
   void initialize(int ecatCycleTime);
   void prepareActuation();
-  // TODO(Martijn) Refactor this to make joint less dependent on knowledge of the IMC
-  void resetIMotionCube();
 
   void actuateRad(double targetPositionRad);
   void actuateTorque(int16_t targetTorque);

--- a/march_hardware/src/IMotionCube.cpp
+++ b/march_hardware/src/IMotionCube.cpp
@@ -276,13 +276,6 @@ void IMotionCube::goToOperationEnabled()
   this->goToTargetState(IMotionCubeTargetState::OPERATION_ENABLED);
 }
 
-void IMotionCube::resetIMotionCube()
-{
-  this->setControlWord(0);
-  ROS_DEBUG("Slave: %d, Try to reset IMC", this->slaveIndex);
-  sdo_bit16(slaveIndex, 0x2080, 0, 1);
-}
-
 ActuationMode IMotionCube::getActuationMode() const
 {
   return this->actuation_mode_;

--- a/march_hardware/src/Joint.cpp
+++ b/march_hardware/src/Joint.cpp
@@ -39,11 +39,6 @@ void Joint::prepareActuation()
   }
 }
 
-void Joint::resetIMotionCube()
-{
-  this->iMotionCube.resetIMotionCube();
-}
-
 void Joint::actuateRad(double targetPositionRad)
 {
   ROS_ASSERT_MSG(this->allowActuation,

--- a/march_hardware_interface/include/march_hardware_interface/march_hardware_interface.h
+++ b/march_hardware_interface/include/march_hardware_interface/march_hardware_interface.h
@@ -73,7 +73,6 @@ private:
   void updatePowerDistributionBoard();
   void updateAfterLimitJointCommand();
   void updateIMotionCubeState();
-  void initiateIMC();
   void outsideLimitsCheck(size_t joint_index);
   void iMotionCubeStateCheck(size_t joint_index);
 

--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -64,8 +64,6 @@ bool MarchHardwareInterface::init(ros::NodeHandle& nh, ros::NodeHandle& /* robot
     soft_limits_[i] = soft_limits;
   }
 
-  initiateIMC();
-
   // Create march_pdb_state interface
   MarchPdbStateHandle march_pdb_state_handle("PDBhandle", &power_distribution_board_read_,
                                              &master_shutdown_allowed_command_, &enable_high_voltage_command_,
@@ -301,20 +299,6 @@ void MarchHardwareInterface::reserveMemory()
   imc_state_pub_->msg_.motion_error_description.resize(num_joints_);
   imc_state_pub_->msg_.motor_current.resize(num_joints_);
   imc_state_pub_->msg_.motor_voltage.resize(num_joints_);
-}
-
-void MarchHardwareInterface::initiateIMC()
-{
-  ROS_INFO("Resetting all IMC on initialization");
-  for (const std::string& joint_name : joint_names_)
-  {
-    Joint joint = march_robot_.getJoint(joint_name);
-    joint.resetIMotionCube();
-  }
-
-  ROS_INFO("Restarting EtherCAT");
-  march_robot_.stopEtherCAT();
-  march_robot_.startEtherCAT();
 }
 
 void MarchHardwareInterface::updatePowerDistributionBoard()


### PR DESCRIPTION

## Description
The new PCBs eliminated the encoder reset problem and therefore the reset IMotionCubes is no longer necessary. This will cause the joints to startup significantly faster :rocket: 

## Changes
* Remove `resetIMotionCube`

<!-- Please don't forget to request for reviews -->
