### PR TITLE
Upload URDF instead of xacro

### DIFF
--- a/march_hardware_interface/launch/hardware.launch
+++ b/march_hardware_interface/launch/hardware.launch
@@ -3,8 +3,7 @@
 
     <rosparam file="$(find march_hardware_interface)/config/$(arg robot)/controllers.yaml" command="load"/>
 
-    <param name="robot_description"
-           command="$(find xacro)/xacro --inorder '$(find march_description)/urdf/$(arg robot).xacro'" />
+    <param name="robot_description" textfile="$(find march_description)/urdf/$(arg robot).urdf"/>
 
     <group ns="march">
         <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>


### PR DESCRIPTION
## Description
Removed the uploading of the xacro and replaced it by uploading the URDF, which is built by `march_description` since project-march/march#457

_(You also no longer get the warning which says that in order processing is the default since lunar. This caused my tab completion on `roslaunch` to do weird stuff.)_


<!-- Please don't forget to request for reviews -->
