### PR TITLE
Fix oopsie by using seconds instead of milliseconds

### DIFF
--- a/march_hardware_interface/src/march_hardware_interface_node.cpp
+++ b/march_hardware_interface/src/march_hardware_interface_node.cpp
@@ -41,8 +41,7 @@ int main(int argc, char** argv)
     return 1;
   }
 
-  const ros::Duration cycle_time(march.getEthercatCycleTime() * ros::param::param<int>("~control_loop_multiplier", 1));
-  ros::Rate rate(cycle_time);
+  ros::Rate rate(march.getEthercatCycleTime() * ros::param::param<int>("~control_loop_multiplier", 1) / 1000.0);
 
   controller_manager::ControllerManager controller_manager(&march, nh);
 


### PR DESCRIPTION
##  Description
Using seconds instead of milliseconds is not a good idea for a control loop :crying_cat_face: 

<!-- Please don't forget to request for reviews -->
