### PR TITLE
Properly shutdown iMotionCubes

### DIFF
--- a/march_hardware/include/march_hardware/IMotionCube.h
+++ b/march_hardware/include/march_hardware/IMotionCube.h
@@ -44,6 +44,7 @@ public:
 
   void goToTargetState(IMotionCubeTargetState target_state);
   void goToOperationEnabled();
+  void shutdown();
 
   /** @brief Override comparison operator */
   friend bool operator==(const IMotionCube& lhs, const IMotionCube& rhs)

--- a/march_hardware/include/march_hardware/Joint.h
+++ b/march_hardware/include/march_hardware/Joint.h
@@ -29,6 +29,7 @@ public:
 
   void initialize(int ecatCycleTime);
   void prepareActuation();
+  void shutdown();
 
   void actuateRad(double targetPositionRad);
   void actuateTorque(int16_t targetTorque);

--- a/march_hardware/src/IMotionCube.cpp
+++ b/march_hardware/src/IMotionCube.cpp
@@ -278,7 +278,7 @@ void IMotionCube::goToOperationEnabled()
 
 void IMotionCube::shutdown()
 {
-    this->goToTargetState(IMotionCubeTargetState::READY_TO_SWITCH_ON);
+  this->goToTargetState(IMotionCubeTargetState::READY_TO_SWITCH_ON);
 }
 
 ActuationMode IMotionCube::getActuationMode() const

--- a/march_hardware/src/IMotionCube.cpp
+++ b/march_hardware/src/IMotionCube.cpp
@@ -276,6 +276,11 @@ void IMotionCube::goToOperationEnabled()
   this->goToTargetState(IMotionCubeTargetState::OPERATION_ENABLED);
 }
 
+void IMotionCube::shutdown()
+{
+    this->goToTargetState(IMotionCubeTargetState::READY_TO_SWITCH_ON);
+}
+
 ActuationMode IMotionCube::getActuationMode() const
 {
   return this->actuation_mode_;

--- a/march_hardware/src/Joint.cpp
+++ b/march_hardware/src/Joint.cpp
@@ -39,6 +39,14 @@ void Joint::prepareActuation()
   }
 }
 
+void Joint::shutdown()
+{
+    if (hasIMotionCube())
+    {
+        iMotionCube.shutdown();
+    }
+}
+
 void Joint::actuateRad(double targetPositionRad)
 {
   ROS_ASSERT_MSG(this->allowActuation,

--- a/march_hardware/src/Joint.cpp
+++ b/march_hardware/src/Joint.cpp
@@ -41,10 +41,10 @@ void Joint::prepareActuation()
 
 void Joint::shutdown()
 {
-    if (hasIMotionCube())
-    {
-        iMotionCube.shutdown();
-    }
+  if (hasIMotionCube())
+  {
+    iMotionCube.shutdown();
+  }
 }
 
 void Joint::actuateRad(double targetPositionRad)

--- a/march_hardware/src/MarchRobot.cpp
+++ b/march_hardware/src/MarchRobot.cpp
@@ -174,9 +174,12 @@ const PowerDistributionBoard& MarchRobot::getPowerDistributionBoard() const
 
 MarchRobot::~MarchRobot()
 {
-  for (auto& joint : jointList)
+  if (this->ethercatMaster.isOperational())
   {
-    joint.shutdown();
+    for (auto& joint : jointList)
+    {
+      joint.shutdown();
+    }
   }
   stopEtherCAT();
 }

--- a/march_hardware/src/MarchRobot.cpp
+++ b/march_hardware/src/MarchRobot.cpp
@@ -174,10 +174,10 @@ const PowerDistributionBoard& MarchRobot::getPowerDistributionBoard() const
 
 MarchRobot::~MarchRobot()
 {
-    for (auto& joint : jointList)
-    {
-        joint.shutdown();
-    }
+  for (auto& joint : jointList)
+  {
+    joint.shutdown();
+  }
   stopEtherCAT();
 }
 

--- a/march_hardware/src/MarchRobot.cpp
+++ b/march_hardware/src/MarchRobot.cpp
@@ -174,6 +174,10 @@ const PowerDistributionBoard& MarchRobot::getPowerDistributionBoard() const
 
 MarchRobot::~MarchRobot()
 {
+    for (auto& joint : jointList)
+    {
+        joint.shutdown();
+    }
   stopEtherCAT();
 }
 


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->

Starting and shutting down exo seems to increase the number of ethercat errors. The Ethercat over Can Manual page 67 says that the IMotion Cubes can be shutdown by having them go to "Ready to switch on", i.e. setting control word to six.

## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->

* Shutdown IMotionCubes in the destructor of the MarchRobot

<!-- Please don't forget to request for reviews -->
