### PR TITLE
Fix: std moving march robot

### DIFF
--- a/march_hardware_builder/include/march_hardware_builder/hardware_builder.h
+++ b/march_hardware_builder/include/march_hardware_builder/hardware_builder.h
@@ -3,6 +3,7 @@
 #define MARCH_HARDWARE_BUILDER_HARDWARE_BUILDER_H
 #include "march_hardware_builder/allowed_robot.h"
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -52,7 +53,7 @@ public:
    * @throws HardwareConfigException When the urdf could not be loaded from the parameter server
    * @throws MissingKeyException When a required key is missing from the given config
    */
-  march::MarchRobot createMarchRobot();
+  std::unique_ptr<march::MarchRobot> createMarchRobot();
 
   /**
    * @brief Loops over all keys in the keyList and check if they exist in the

--- a/march_hardware_builder/src/hardware_builder.cpp
+++ b/march_hardware_builder/src/hardware_builder.cpp
@@ -2,6 +2,7 @@
 #include "march_hardware_builder/hardware_builder.h"
 #include "march_hardware_builder/hardware_config_exceptions.h"
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -43,7 +44,7 @@ HardwareBuilder::HardwareBuilder(const std::string& yaml_path, urdf::Model urdf)
 {
 }
 
-march::MarchRobot HardwareBuilder::createMarchRobot()
+std::unique_ptr<march::MarchRobot> HardwareBuilder::createMarchRobot()
 {
   this->initUrdf();
 
@@ -71,12 +72,12 @@ march::MarchRobot HardwareBuilder::createMarchRobot()
   if (pdb_config)
   {
     march::PowerDistributionBoard pdb = HardwareBuilder::createPowerDistributionBoard(pdb_config);
-    return { joint_list, this->urdf_, pdb, if_name, cycle_time };
+    return std::make_unique<march::MarchRobot>(joint_list, this->urdf_, pdb, if_name, cycle_time);
   }
   else
   {
     ROS_INFO("powerDistributionBoard is NOT defined");
-    return { joint_list, this->urdf_, if_name, cycle_time };
+    return std::make_unique<march::MarchRobot>(joint_list, this->urdf_, if_name, cycle_time);
   }
 }
 

--- a/march_hardware_interface/include/march_hardware_interface/march_hardware_interface.h
+++ b/march_hardware_interface/include/march_hardware_interface/march_hardware_interface.h
@@ -34,7 +34,7 @@ using RtPublisherPtr = std::unique_ptr<realtime_tools::RealtimePublisher<T>>;
 class MarchHardwareInterface : public hardware_interface::RobotHW
 {
 public:
-  explicit MarchHardwareInterface(march::MarchRobot robot);
+  explicit MarchHardwareInterface(std::unique_ptr<march::MarchRobot> robot);
 
   /**
    * @brief Initialize the HardwareInterface by registering position interfaces
@@ -84,7 +84,7 @@ private:
   static constexpr double ALPHA = 0.2;
 
   /* March hardware */
-  march::MarchRobot march_robot_;
+  std::unique_ptr<march::MarchRobot> march_robot_;
   bool has_power_distribution_board_ = false;
 
   /* Interfaces */

--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -2,6 +2,7 @@
 #include "march_hardware_interface/march_hardware_interface.h"
 #include "march_hardware_interface/power_net_on_off_command.h"
 
+#include <memory>
 #include <sstream>
 #include <string>
 
@@ -22,12 +23,12 @@ using joint_limits_interface::PositionJointSoftLimitsHandle;
 using joint_limits_interface::SoftJointLimits;
 using march::Joint;
 
-MarchHardwareInterface::MarchHardwareInterface(march::MarchRobot robot)
+MarchHardwareInterface::MarchHardwareInterface(std::unique_ptr<march::MarchRobot> robot)
   : march_robot_(std::move(robot))
-  , has_power_distribution_board_(this->march_robot_.getPowerDistributionBoard().getSlaveIndex() != -1)
+  , has_power_distribution_board_(this->march_robot_->getPowerDistributionBoard().getSlaveIndex() != -1)
 {
   // Get joint names from urdf
-  for (const auto& urdf_joint : this->march_robot_.getUrdf().joints_)
+  for (const auto& urdf_joint : this->march_robot_->getUrdf().joints_)
   {
     if (urdf_joint.second->type != urdf::Joint::FIXED)
     {
@@ -53,12 +54,12 @@ bool MarchHardwareInterface::init(ros::NodeHandle& nh, ros::NodeHandle& /* robot
   this->reserveMemory();
 
   // Start ethercat cycle in the hardware
-  this->march_robot_.startEtherCAT();
+  this->march_robot_->startEtherCAT();
 
   for (size_t i = 0; i < num_joints_; ++i)
   {
     SoftJointLimits soft_limits;
-    getSoftJointLimits(this->march_robot_.getUrdf().getJoint(joint_names_[i]), soft_limits);
+    getSoftJointLimits(this->march_robot_->getUrdf().getJoint(joint_names_[i]), soft_limits);
     ROS_DEBUG("[%s] Soft limits set to (%f, %f)", joint_names_[i].c_str(), soft_limits.min_position,
               soft_limits.max_position);
     soft_limits_[i] = soft_limits;
@@ -82,16 +83,16 @@ bool MarchHardwareInterface::init(ros::NodeHandle& nh, ros::NodeHandle& /* robot
   {
     for (size_t i = 0; i < num_joints_; i++)
     {
-      int net_number = march_robot_.getJoint(joint_names_[i]).getNetNumber();
+      int net_number = march_robot_->getJoint(joint_names_[i]).getNetNumber();
       if (net_number == -1)
       {
         std::ostringstream error_stream;
         error_stream << "Joint " << joint_names_[i].c_str() << " has no net number";
         throw std::runtime_error(error_stream.str());
       }
-      while (!march_robot_.getPowerDistributionBoard().getHighVoltage().getNetOperational(net_number))
+      while (!march_robot_->getPowerDistributionBoard().getHighVoltage().getNetOperational(net_number))
       {
-        march_robot_.getPowerDistributionBoard().getHighVoltage().setNetOnOff(true, net_number);
+        march_robot_->getPowerDistributionBoard().getHighVoltage().setNetOnOff(true, net_number);
         usleep(100000);
         ROS_WARN("[%s] Waiting on high voltage", joint_names_[i].c_str());
       }
@@ -105,14 +106,14 @@ bool MarchHardwareInterface::init(ros::NodeHandle& nh, ros::NodeHandle& /* robot
   // Initialize interfaces for each joint
   for (size_t i = 0; i < num_joints_; ++i)
   {
-    march::Joint joint = march_robot_.getJoint(joint_names_[i]);
+    march::Joint joint = march_robot_->getJoint(joint_names_[i]);
     // Create joint state interface
     JointStateHandle joint_state_handle(joint.getName(), &joint_position_[i], &joint_velocity_[i], &joint_effort_[i]);
     joint_state_interface_.registerHandle(joint_state_handle);
 
     // Retrieve joint (soft) limits from the urdf
     JointLimits limits;
-    getJointLimits(this->march_robot_.getUrdf().getJoint(joint.getName()), limits);
+    getJointLimits(this->march_robot_->getUrdf().getJoint(joint.getName()), limits);
 
     if (joint.getActuationMode() == march::ActuationMode::position)
     {
@@ -152,7 +153,7 @@ bool MarchHardwareInterface::init(ros::NodeHandle& nh, ros::NodeHandle& /* robot
         int net_number = joint.getNetNumber();
         if (net_number != -1)
         {
-          march_robot_.getPowerDistributionBoard().getHighVoltage().setNetOnOff(true, net_number);
+          march_robot_->getPowerDistributionBoard().getHighVoltage().setNetOnOff(true, net_number);
         }
         else
         {
@@ -196,7 +197,7 @@ void MarchHardwareInterface::read(const ros::Time& /* time */, const ros::Durati
   {
     const double old_position = joint_position_[i];
 
-    march::Joint joint = march_robot_.getJoint(joint_names_[i]);
+    march::Joint joint = march_robot_->getJoint(joint_names_[i]);
 
     joint_position_[i] = joint.getAngleRadAbsolute();
 
@@ -221,7 +222,7 @@ void MarchHardwareInterface::read(const ros::Time& /* time */, const ros::Durati
 
   if (has_power_distribution_board_)
   {
-    power_distribution_board_read_ = march_robot_.getPowerDistributionBoard();
+    power_distribution_board_read_ = march_robot_->getPowerDistributionBoard();
 
     if (!power_distribution_board_read_.getHighVoltage().getHighVoltageEnabled())
     {
@@ -246,7 +247,7 @@ void MarchHardwareInterface::write(const ros::Time& /* time */, const ros::Durat
 
   for (size_t i = 0; i < num_joints_; i++)
   {
-    march::Joint joint = march_robot_.getJoint(joint_names_[i]);
+    march::Joint joint = march_robot_->getJoint(joint_names_[i]);
 
     if (joint.canActuate())
     {
@@ -276,7 +277,7 @@ void MarchHardwareInterface::write(const ros::Time& /* time */, const ros::Durat
 
 int MarchHardwareInterface::getEthercatCycleTime() const
 {
-  return this->march_robot_.getEthercatCycleTime();
+  return this->march_robot_->getEthercatCycleTime();
 }
 
 void MarchHardwareInterface::reserveMemory()
@@ -309,8 +310,8 @@ void MarchHardwareInterface::reserveMemory()
 
 void MarchHardwareInterface::updatePowerDistributionBoard()
 {
-  march_robot_.getPowerDistributionBoard().setMasterOnline();
-  march_robot_.getPowerDistributionBoard().setMasterShutDownAllowed(master_shutdown_allowed_command_);
+  march_robot_->getPowerDistributionBoard().setMasterOnline();
+  march_robot_->getPowerDistributionBoard().setMasterShutDownAllowed(master_shutdown_allowed_command_);
   updateHighVoltageEnable();
   updatePowerNet();
 }
@@ -319,12 +320,12 @@ void MarchHardwareInterface::updateHighVoltageEnable()
 {
   try
   {
-    if (march_robot_.getPowerDistributionBoard().getHighVoltage().getHighVoltageEnabled() !=
+    if (march_robot_->getPowerDistributionBoard().getHighVoltage().getHighVoltageEnabled() !=
         enable_high_voltage_command_)
     {
-      march_robot_.getPowerDistributionBoard().getHighVoltage().enableDisableHighVoltage(enable_high_voltage_command_);
+      march_robot_->getPowerDistributionBoard().getHighVoltage().enableDisableHighVoltage(enable_high_voltage_command_);
     }
-    else if (!march_robot_.getPowerDistributionBoard().getHighVoltage().getHighVoltageEnabled())
+    else if (!march_robot_->getPowerDistributionBoard().getHighVoltage().getHighVoltageEnabled())
     {
       ROS_WARN_THROTTLE(2, "High voltage disabled");
     }
@@ -344,10 +345,10 @@ void MarchHardwareInterface::updatePowerNet()
   {
     try
     {
-      if (march_robot_.getPowerDistributionBoard().getHighVoltage().getNetOperational(
+      if (march_robot_->getPowerDistributionBoard().getHighVoltage().getNetOperational(
               power_net_on_off_command_.getNetNumber()) != power_net_on_off_command_.isOnOrOff())
       {
-        march_robot_.getPowerDistributionBoard().getHighVoltage().setNetOnOff(power_net_on_off_command_.isOnOrOff(),
+        march_robot_->getPowerDistributionBoard().getHighVoltage().setNetOnOff(power_net_on_off_command_.isOnOrOff(),
                                                                               power_net_on_off_command_.getNetNumber());
       }
     }
@@ -362,10 +363,10 @@ void MarchHardwareInterface::updatePowerNet()
   {
     try
     {
-      if (march_robot_.getPowerDistributionBoard().getLowVoltage().getNetOperational(
+      if (march_robot_->getPowerDistributionBoard().getLowVoltage().getNetOperational(
               power_net_on_off_command_.getNetNumber()) != power_net_on_off_command_.isOnOrOff())
       {
-        march_robot_.getPowerDistributionBoard().getLowVoltage().setNetOnOff(power_net_on_off_command_.isOnOrOff(),
+        march_robot_->getPowerDistributionBoard().getLowVoltage().setNetOnOff(power_net_on_off_command_.isOnOrOff(),
                                                                              power_net_on_off_command_.getNetNumber());
       }
     }
@@ -388,7 +389,7 @@ void MarchHardwareInterface::updateAfterLimitJointCommand()
   after_limit_joint_command_pub_->msg_.header.stamp = ros::Time::now();
   for (size_t i = 0; i < num_joints_; i++)
   {
-    march::Joint joint = march_robot_.getJoint(joint_names_[i]);
+    march::Joint joint = march_robot_->getJoint(joint_names_[i]);
 
     after_limit_joint_command_pub_->msg_.name[i] = joint.getName();
     after_limit_joint_command_pub_->msg_.position_command[i] = joint_position_command_[i];
@@ -408,7 +409,7 @@ void MarchHardwareInterface::updateIMotionCubeState()
   imc_state_pub_->msg_.header.stamp = ros::Time::now();
   for (size_t i = 0; i < num_joints_; i++)
   {
-    march::IMotionCubeState imc_state = march_robot_.getJoint(joint_names_[i]).getIMotionCubeState();
+    march::IMotionCubeState imc_state = march_robot_->getJoint(joint_names_[i]).getIMotionCubeState();
     imc_state_pub_->msg_.header.stamp = ros::Time::now();
     imc_state_pub_->msg_.joint_names[i] = joint_names_[i];
     imc_state_pub_->msg_.status_word[i] = imc_state.statusWord;
@@ -427,7 +428,7 @@ void MarchHardwareInterface::updateIMotionCubeState()
 
 void MarchHardwareInterface::iMotionCubeStateCheck(size_t joint_index)
 {
-  march::IMotionCubeState imc_state = march_robot_.getJoint(joint_names_[joint_index]).getIMotionCubeState();
+  march::IMotionCubeState imc_state = march_robot_->getJoint(joint_names_[joint_index]).getIMotionCubeState();
   if (imc_state.state == march::IMCState::FAULT)
   {
     std::ostringstream error_stream;
@@ -445,7 +446,7 @@ void MarchHardwareInterface::iMotionCubeStateCheck(size_t joint_index)
 
 void MarchHardwareInterface::outsideLimitsCheck(size_t joint_index)
 {
-  march::Joint joint = march_robot_.getJoint(joint_names_[joint_index]);
+  march::Joint joint = march_robot_->getJoint(joint_names_[joint_index]);
   if (joint_position_[joint_index] < soft_limits_[joint_index].min_position ||
       joint_position_[joint_index] > soft_limits_[joint_index].max_position)
   {

--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -348,8 +348,8 @@ void MarchHardwareInterface::updatePowerNet()
       if (march_robot_->getPowerDistributionBoard().getHighVoltage().getNetOperational(
               power_net_on_off_command_.getNetNumber()) != power_net_on_off_command_.isOnOrOff())
       {
-        march_robot_->getPowerDistributionBoard().getHighVoltage().setNetOnOff(power_net_on_off_command_.isOnOrOff(),
-                                                                              power_net_on_off_command_.getNetNumber());
+        march_robot_->getPowerDistributionBoard().getHighVoltage().setNetOnOff(
+            power_net_on_off_command_.isOnOrOff(), power_net_on_off_command_.getNetNumber());
       }
     }
     catch (std::exception& exception)
@@ -367,7 +367,7 @@ void MarchHardwareInterface::updatePowerNet()
               power_net_on_off_command_.getNetNumber()) != power_net_on_off_command_.isOnOrOff())
       {
         march_robot_->getPowerDistributionBoard().getLowVoltage().setNetOnOff(power_net_on_off_command_.isOnOrOff(),
-                                                                             power_net_on_off_command_.getNetNumber());
+                                                                              power_net_on_off_command_.getNetNumber());
       }
     }
     catch (std::exception& exception)


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

## Description
Fixed the issue where ethercat was trying to close while it was not active. Since the `MarchRobot` was moved in the `MarchHardwareInterface` the destructor was called on the old `MarchRobot`, which caused it to close the ethercat connection. I have replaced this with a `std::unique_ptr`, so now it moves the pointer around and keeps one instance of the `MarchRobot`.

## Changes
* Make `HardwareBuilder` return `std::unique_ptr<MarchRobot>`
* Move `std::unique_ptr` instead of instance

<!-- Please don't forget to request for reviews -->
