### PR TITLE
Fix: remove debug statements in real time safe loop

### DIFF
--- a/march_hardware/src/EtherCAT/EthercatMaster.cpp
+++ b/march_hardware/src/EtherCAT/EthercatMaster.cpp
@@ -174,11 +174,6 @@ void EthercatMaster::ethercatLoop()
         ROS_WARN("EtherCAT rate of %d milliseconds per cycle was not achieved for %f percent of all cycles",
                  cycle_time_ms_, rateNotAchievedPercentage);
       }
-      else
-      {
-        ROS_DEBUG("EtherCAT rate of %d milliseconds per cycle was not achieved for %f percent of all cycles",
-                  cycle_time_ms_, rateNotAchievedPercentage);
-      }
       totalLoops = 0;
       rateNotAchievedCount = 0;
     }

--- a/march_hardware/src/IMotionCube.cpp
+++ b/march_hardware/src/IMotionCube.cpp
@@ -129,8 +129,6 @@ void IMotionCube::actuateIU(int32_t target_iu)
 
   uint8_t target_position_location = this->mosi_byte_offsets_.at(IMCObjectName::TargetPosition);
 
-  ROS_DEBUG("Trying to actuate slave %d, soem location %d to targetposition %d", this->slaveIndex,
-            target_position_location, target_position.i);
   set_output_bit32(this->slaveIndex, target_position_location, target_position);
 }
 
@@ -153,8 +151,6 @@ void IMotionCube::actuateTorque(int16_t target_torque)
 
   uint8_t target_torque_location = this->mosi_byte_offsets_.at(IMCObjectName::TargetTorque);
 
-  ROS_DEBUG("Trying to actuate slave %d, soem location %d with target torque %d", this->slaveIndex,
-            target_torque_location, target_torque_struct.i);
   set_output_bit16(this->slaveIndex, target_torque_location, target_torque_struct);
 }
 
@@ -176,7 +172,6 @@ double IMotionCube::getAngleRadIncremental()
 int16_t IMotionCube::getTorque()
 {
   bit16 return_byte = get_input_bit16(this->slaveIndex, this->miso_byte_offsets_.at(IMCObjectName::ActualTorque));
-  ROS_DEBUG("Actual Torque read: %d", return_byte.i);
   return return_byte.i;
 }
 

--- a/march_hardware/src/MarchRobot.cpp
+++ b/march_hardware/src/MarchRobot.cpp
@@ -157,8 +157,7 @@ Joint MarchRobot::getJoint(::std::string jointName)
     }
   }
 
-  ROS_ERROR("Could not find joint with name %s", jointName.c_str());
-  throw ::std::runtime_error("Could not find joint with name " + jointName);
+  throw std::runtime_error("Could not find joint with name " + jointName);
 }
 
 PowerDistributionBoard& MarchRobot::getPowerDistributionBoard()

--- a/march_hardware_interface/include/march_hardware_interface/march_hardware_interface.h
+++ b/march_hardware_interface/include/march_hardware_interface/march_hardware_interface.h
@@ -43,7 +43,8 @@ public:
   bool init(ros::NodeHandle& nh, ros::NodeHandle& robot_hw_nh) override;
 
   /**
-   * @brief Read actual position from the hardware.
+   * Reads (in realtime) the state from the march robot.
+   *
    * @param time Current time
    * @param elapsed_time Duration since last write action
    */
@@ -55,7 +56,8 @@ public:
   void validate();
 
   /**
-   * @brief Write position commands to the hardware.
+   * Writes (in realtime) the commands from the controllers to the march robot.
+   *
    * @param time Current time
    * @param elapsed_time Duration since last write action
    */

--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -213,8 +213,6 @@ void MarchHardwareInterface::read(const ros::Time& /* time */, const ros::Durati
         MarchHardwareInterface::ALPHA * joint_velocity + (1 - MarchHardwareInterface::ALPHA) * joint_velocity_[i];
 
     joint_effort_[i] = joint.getTorque();
-
-    ROS_DEBUG("Joint %s: read position %f", joint_names_[i].c_str(), joint_position_[i]);
   }
 
   this->updateIMotionCubeState();
@@ -222,11 +220,6 @@ void MarchHardwareInterface::read(const ros::Time& /* time */, const ros::Durati
   if (has_power_distribution_board_)
   {
     power_distribution_board_read_ = march_robot_.getPowerDistributionBoard();
-
-    if (!power_distribution_board_read_.getHighVoltage().getHighVoltageEnabled())
-    {
-      ROS_WARN_THROTTLE(10, "All-High-Voltage disabled");
-    }
   }
 }
 
@@ -250,11 +243,6 @@ void MarchHardwareInterface::write(const ros::Time& /* time */, const ros::Durat
 
     if (joint.canActuate())
     {
-      ROS_DEBUG("After limits: Trying to actuate joint %s, to %lf rad, %f "
-                "speed, %f effort.",
-                joint_names_[i].c_str(), joint_position_command_[i], joint_velocity_command_[i],
-                joint_effort_command_[i]);
-
       if (joint.getActuationMode() == march::ActuationMode::position)
       {
         joint.actuateRad(joint_position_command_[i]);
@@ -438,7 +426,6 @@ void MarchHardwareInterface::iMotionCubeStateCheck(size_t joint_index)
     error_stream << "Motion Error: " << imc_state.motionErrorDescription << "(" << imc_state.motionError << ")"
                  << std::endl;
 
-    ROS_FATAL("%s", error_stream.str().c_str());
     throw std::runtime_error(error_stream.str());
   }
 }
@@ -459,8 +446,7 @@ void MarchHardwareInterface::outsideLimitsCheck(size_t joint_index)
       error_stream << "Joint " << joint_names_[joint_index].c_str() << " is out of its soft limits ("
                    << soft_limits_[joint_index].min_position << ", " << soft_limits_[joint_index].max_position
                    << "). Actual position: " << joint_position_[joint_index];
-      ROS_FATAL("%s", error_stream.str().c_str());
-      throw ::std::runtime_error(error_stream.str());
+      throw std::runtime_error(error_stream.str());
     }
   }
 }

--- a/march_pdb_state_controller/src/march_pdb_state_controller.cpp
+++ b/march_pdb_state_controller/src/march_pdb_state_controller.cpp
@@ -129,7 +129,6 @@ MarchPdbStateController::createLowVoltageNetsMessage(march::LowVoltage low_volta
 
 void MarchPdbStateController::update(const ros::Time& time, const ros::Duration& /*period*/)
 {
-  ROS_DEBUG_THROTTLE(1, "update MarchPdbStateController");
   // limit rate of publishing
   if (publish_rate_ > 0.0 && last_publish_times_ + ros::Duration(1.0 / publish_rate_) < time)
   {


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

## Description
Removed debug statements in real time safe loop, to avoid nondeterministic behavior when printing.

See [this thread](https://answers.ros.org/question/302486/does-ros_info-break-realtime/) on ROS answers.

## Changes
* Remove `ROS_DEBUG` statements
* Remove redundant `ROS_ERROR` and `ROS_FATAL` before throwing exception

<!-- Please don't forget to request for reviews -->
