### PR TITLE
Fix: ethercat loop

### DIFF
--- a/march_hardware/include/march_hardware/EtherCAT/EthercatMaster.h
+++ b/march_hardware/include/march_hardware/EtherCAT/EthercatMaster.h
@@ -1,6 +1,7 @@
 // Copyright 2019 Project March.
 #ifndef MARCH_HARDWARE_ETHERCAT_ETHERCATMASTER_H
 #define MARCH_HARDWARE_ETHERCAT_ETHERCATMASTER_H
+#include <atomic>
 #include <vector>
 #include <string>
 #include <thread>
@@ -28,7 +29,7 @@ public:
   EthercatMaster& operator=(const EthercatMaster&) = delete;
 
   /* Enable the move constructor */
-  EthercatMaster(EthercatMaster&&) = default;
+  EthercatMaster(EthercatMaster&&) = delete;
   EthercatMaster& operator=(EthercatMaster&&) = delete;
 
   bool isOperational() const;
@@ -77,7 +78,7 @@ private:
    */
   static void monitorSlaveConnection();
 
-  bool is_operational_ = false;
+  std::atomic<bool> is_operational_;
 
   const std::string ifname_;
   const int max_slave_index_;

--- a/march_hardware/include/march_hardware/EtherCAT/EthercatMaster.h
+++ b/march_hardware/include/march_hardware/EtherCAT/EthercatMaster.h
@@ -28,7 +28,7 @@ public:
   EthercatMaster(const EthercatMaster&) = delete;
   EthercatMaster& operator=(const EthercatMaster&) = delete;
 
-  /* Enable the move constructor */
+  /* Delete move constructor/assignment since atomic bool can not be moved */
   EthercatMaster(EthercatMaster&&) = delete;
   EthercatMaster& operator=(EthercatMaster&&) = delete;
 

--- a/march_hardware/include/march_hardware/EtherCAT/EthercatMaster.h
+++ b/march_hardware/include/march_hardware/EtherCAT/EthercatMaster.h
@@ -71,7 +71,7 @@ private:
   /**
    * Sends the PDO and receives the working counter and check if this is lower than expected.
    */
-  void SendReceivePDO();
+  void sendReceivePdo();
 
   /**
    * Checks if all the slaves are connected and in operational state.

--- a/march_hardware/include/march_hardware/EtherCAT/EthercatMaster.h
+++ b/march_hardware/include/march_hardware/EtherCAT/EthercatMaster.h
@@ -28,7 +28,7 @@ public:
   EthercatMaster(const EthercatMaster&) = delete;
   EthercatMaster& operator=(const EthercatMaster&) = delete;
 
-  /* Delete move constructor/assignment since atomic bool can not be moved */
+  /* Delete move constructor/assignment since atomic bool cannot be moved */
   EthercatMaster(EthercatMaster&&) = delete;
   EthercatMaster& operator=(EthercatMaster&&) = delete;
 

--- a/march_hardware/include/march_hardware/MarchRobot.h
+++ b/march_hardware/include/march_hardware/MarchRobot.h
@@ -3,9 +3,9 @@
 #ifndef MARCH_HARDWARE_MARCHROBOT_H
 #define MARCH_HARDWARE_MARCHROBOT_H
 
+#include <cstdint>
 #include <string>
 #include <vector>
-#include <stdint.h>
 
 #include <urdf/model.h>
 
@@ -37,7 +37,7 @@ public:
   MarchRobot& operator=(const MarchRobot&) = delete;
 
   /* Enable the move constructor */
-  MarchRobot(MarchRobot&&) = default;
+  MarchRobot(MarchRobot&&) = delete;
   MarchRobot& operator=(MarchRobot&&) = delete;
 
   void startEtherCAT();

--- a/march_hardware/include/march_hardware/MarchRobot.h
+++ b/march_hardware/include/march_hardware/MarchRobot.h
@@ -36,7 +36,7 @@ public:
   MarchRobot(const MarchRobot&) = delete;
   MarchRobot& operator=(const MarchRobot&) = delete;
 
-  /* Enable the move constructor */
+  /* Delete move constructor/assignment since atomic bool cannot be moved */
   MarchRobot(MarchRobot&&) = delete;
   MarchRobot& operator=(MarchRobot&&) = delete;
 

--- a/march_hardware/src/EtherCAT/EthercatMaster.cpp
+++ b/march_hardware/src/EtherCAT/EthercatMaster.cpp
@@ -148,13 +148,13 @@ void EthercatMaster::ethercatLoop()
 
   while (this->is_operational_)
   {
-    const auto begin = std::chrono::high_resolution_clock::now();
+    const auto begin_time = std::chrono::high_resolution_clock::now();
 
     this->sendReceivePdo();
     monitorSlaveConnection();
 
-    const auto end = std::chrono::high_resolution_clock::now();
-    const auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - begin);
+    const auto end_time = std::chrono::high_resolution_clock::now();
+    const auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end_time - begin_time);
 
     if (duration > cycle_time)
     {

--- a/march_hardware/src/EtherCAT/EthercatMaster.cpp
+++ b/march_hardware/src/EtherCAT/EthercatMaster.cpp
@@ -145,29 +145,16 @@ void EthercatMaster::ethercatLoop()
   size_t not_achieved_count = 0;
   const size_t rate = 1000 / this->cycle_time_ms_;
   const std::chrono::milliseconds cycle_time(this->cycle_time_ms_);
-  auto end_time = std::chrono::high_resolution_clock::now();
 
   while (this->is_operational_)
   {
-    const auto start_time = std::chrono::high_resolution_clock::now();
-    const auto down_time = std::chrono::duration_cast<std::chrono::microseconds>(start_time - end_time);
-    if (down_time > cycle_time)
-    {
-      ROS_WARN("There was %d milliseconds between two EtherCAT calls, while cycle time is %d milliseconds",
-               down_time.count(), this->cycle_time_ms_);
-    }
+    const auto begin = std::chrono::high_resolution_clock::now();
 
     this->sendReceivePdo();
     monitorSlaveConnection();
 
-    end_time = std::chrono::high_resolution_clock::now();
-    const auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end_time - start_time);
-
-    if (duration > 2 * cycle_time)
-    {
-      ROS_WARN("EtherCAT execution took %d milliseconds, while cycle time is %d milliseconds", duration.count(),
-               this->cycle_time_ms_);
-    }
+    const auto end = std::chrono::high_resolution_clock::now();
+    const auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - begin);
 
     if (duration > cycle_time)
     {

--- a/march_hardware/src/EtherCAT/EthercatMaster.cpp
+++ b/march_hardware/src/EtherCAT/EthercatMaster.cpp
@@ -23,7 +23,7 @@
 namespace march
 {
 EthercatMaster::EthercatMaster(std::string ifname, int max_slave_index, int cycle_time)
-  : ifname_(std::move(ifname)), max_slave_index_(max_slave_index), cycle_time_ms_(cycle_time)
+  : is_operational_(false), ifname_(std::move(ifname)), max_slave_index_(max_slave_index), cycle_time_ms_(cycle_time)
 {
 }
 

--- a/march_hardware/src/MarchRobot.cpp
+++ b/march_hardware/src/MarchRobot.cpp
@@ -18,7 +18,7 @@ namespace march
 MarchRobot::MarchRobot(::std::vector<Joint> jointList, urdf::Model urdf, ::std::string ifName, int ecatCycleTime)
   : jointList(std::move(jointList))
   , urdf_(std::move(urdf))
-  , ethercatMaster(EthercatMaster(ifName, this->getMaxSlaveIndex(), ecatCycleTime))
+  , ethercatMaster(ifName, this->getMaxSlaveIndex(), ecatCycleTime)
 {
 }
 
@@ -26,7 +26,7 @@ MarchRobot::MarchRobot(::std::vector<Joint> jointList, urdf::Model urdf, PowerDi
                        ::std::string ifName, int ecatCycleTime)
   : jointList(std::move(jointList))
   , urdf_(std::move(urdf))
-  , ethercatMaster(EthercatMaster(ifName, this->getMaxSlaveIndex(), ecatCycleTime))
+  , ethercatMaster(ifName, this->getMaxSlaveIndex(), ecatCycleTime)
   , powerDistributionBoard(powerDistributionBoard)
 {
 }


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

## Description
Fixed an issue in `EthercatMaster` where the `is_operational_` member could be written to and read from at the same time. This results in undefined behaviour (even though it is a bool). So I changed it to a `std::atomic<bool>` which guarantees atomic reading and writing.

Furthermore, the `ethercatLoop` was using `boost::chrono` for its timing. However, Boost was not included in the project and the same functionality exists in the standard library. I changed it to using durations, which is a lot nicer to read, since you no longer have to convert microseconds to milliseconds and so on.

## Changes
* Changed `is_operational_` type from `bool` to `std::atomic<bool>`
* Use `std::chrono` instead of `boost::chrono`
* Add some `this->` to members to be more consistent and distinct them from the `soem` library functions

<!-- Please don't forget to request for reviews -->
