### PR TITLE
Fix/stop ethercat when imc fault

### DIFF
--- a/march_hardware/src/EtherCAT/EthercatMaster.cpp
+++ b/march_hardware/src/EtherCAT/EthercatMaster.cpp
@@ -23,7 +23,7 @@
 namespace march
 {
 EthercatMaster::EthercatMaster(std::string ifname, int max_slave_index, int cycle_time)
-  : ifname_(std::move(ifname)), max_slave_index_(max_slave_index), cycle_time_ms_(cycle_time)
+    : ifname_(std::move(ifname)), max_slave_index_(max_slave_index), cycle_time_ms_(cycle_time)
 {
 }
 

--- a/march_hardware/src/EtherCAT/EthercatMaster.cpp
+++ b/march_hardware/src/EtherCAT/EthercatMaster.cpp
@@ -186,7 +186,7 @@ void EthercatMaster::SendReceivePDO()
   int wkc = ec_receive_processdata(EC_TIMEOUTRET);
   if (wkc < this->expected_working_counter_)
   {
-    ROS_WARN_THROTTLE(1, "Working counter lower than expected. EtherCAT connection may not be optimal");
+    ROS_WARN_THROTTLE(1, "Working counter: %d  is lower than expected: %d", wkc, this->expected_working_counter_);
   }
 }
 

--- a/march_hardware/src/EtherCAT/EthercatMaster.cpp
+++ b/march_hardware/src/EtherCAT/EthercatMaster.cpp
@@ -23,7 +23,7 @@
 namespace march
 {
 EthercatMaster::EthercatMaster(std::string ifname, int max_slave_index, int cycle_time)
-    : ifname_(std::move(ifname)), max_slave_index_(max_slave_index), cycle_time_ms_(cycle_time)
+  : ifname_(std::move(ifname)), max_slave_index_(max_slave_index), cycle_time_ms_(cycle_time)
 {
 }
 

--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -428,7 +428,6 @@ void MarchHardwareInterface::iMotionCubeStateCheck(size_t joint_index)
     error_stream << "Motion Error: " << imc_state.motionErrorDescription << "(" << imc_state.motionError << ")"
                  << std::endl;
 
-
     throw std::runtime_error(error_stream.str());
   }
 }

--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -428,6 +428,7 @@ void MarchHardwareInterface::iMotionCubeStateCheck(size_t joint_index)
     error_stream << "Motion Error: " << imc_state.motionErrorDescription << "(" << imc_state.motionError << ")"
                  << std::endl;
 
+
     throw std::runtime_error(error_stream.str());
   }
 }

--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -419,6 +419,7 @@ void MarchHardwareInterface::iMotionCubeStateCheck(size_t joint_index)
   march::IMotionCubeState imc_state = march_robot_->getJoint(joint_names_[joint_index]).getIMotionCubeState();
   if (imc_state.state == march::IMCState::FAULT)
   {
+    this->march_robot_->stopEtherCAT();
     std::ostringstream error_stream;
     error_stream << "IMotionCube of joint " << joint_names_[joint_index].c_str() << " is in fault state "
                  << imc_state.state.getString() << std::endl;


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->


## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->

When an IMotionCube goes to fault state, it takes approximately 0.4 seconds before the master shuts ethercat down. If this happens due to something that is not an ethercat error, there will be seven IMC that do not go to fault state until the master shuts down ethercat. However, the master no longer updates the efforts, so the IMCs continue sending their previous effort as long as ethercat is active. Hence it takes 0.45 seconds (0.4 + watchdog) until the joints do a quickstop. 

This PR stops ethercat immediately after a fault state is detected, instead of waiting for the destructor of MarchRobot to start.

## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->

<!-- Please don't forget to request for reviews -->
