### PR TITLE
Only update controllers if ethercat train has returned

### DIFF
--- a/march_hardware/include/march_hardware/EtherCAT/EthercatMaster.h
+++ b/march_hardware/include/march_hardware/EtherCAT/EthercatMaster.h
@@ -33,6 +33,8 @@ public:
   EthercatMaster& operator=(EthercatMaster&&) = delete;
 
   bool isOperational() const;
+  bool getTrainReturned();
+  void setTrainReturned(bool train_returned);
 
   /**
    * Returns the cycle time in milliseconds.
@@ -83,6 +85,7 @@ private:
   const std::string ifname_;
   const int max_slave_index_;
   const int cycle_time_ms_;
+  bool train_returned_ = false;
 
   char io_map_[4096] = { 0 };
   int expected_working_counter_ = 0;

--- a/march_hardware/include/march_hardware/EtherCAT/EthercatMaster.h
+++ b/march_hardware/include/march_hardware/EtherCAT/EthercatMaster.h
@@ -5,6 +5,8 @@
 #include <vector>
 #include <string>
 #include <thread>
+#include <mutex>
+#include <condition_variable>
 
 #include <march_hardware/Joint.h>
 
@@ -33,8 +35,7 @@ public:
   EthercatMaster& operator=(EthercatMaster&&) = delete;
 
   bool isOperational() const;
-  bool getTrainReturned();
-  void setTrainReturned(bool train_returned);
+  void waitForPdo();
 
   /**
    * Returns the cycle time in milliseconds.
@@ -85,7 +86,10 @@ private:
   const std::string ifname_;
   const int max_slave_index_;
   const int cycle_time_ms_;
-  bool train_returned_ = false;
+
+  std::mutex wait_on_pdo_condition_mutex_;
+  std::condition_variable wait_on_pdo_condition_var_;
+  bool pdo_received_ = false;
 
   char io_map_[4096] = { 0 };
   int expected_working_counter_ = 0;

--- a/march_hardware/include/march_hardware/Joint.h
+++ b/march_hardware/include/march_hardware/Joint.h
@@ -19,7 +19,7 @@ private:
   // Set this number via the hardware builder
   int netNumber;
   bool allowActuation;
-  float previous_motor_volt_;
+  float previous_motor_volt_ = 0.0;
   IMotionCube iMotionCube;
   TemperatureGES temperatureGES;
 

--- a/march_hardware/include/march_hardware/Joint.h
+++ b/march_hardware/include/march_hardware/Joint.h
@@ -19,6 +19,7 @@ private:
   // Set this number via the hardware builder
   int netNumber;
   bool allowActuation;
+  float previous_motor_volt_;
   IMotionCube iMotionCube;
   TemperatureGES temperatureGES;
 
@@ -56,6 +57,7 @@ public:
   bool hasIMotionCube();
   bool hasTemperatureGES();
   bool canActuate();
+  bool receivedDataUpdate();
 
   /** @brief Override comparison operator */
   friend bool operator==(const Joint& lhs, const Joint& rhs)

--- a/march_hardware/include/march_hardware/MarchRobot.h
+++ b/march_hardware/include/march_hardware/MarchRobot.h
@@ -50,8 +50,7 @@ public:
 
   bool isEthercatOperational();
 
-  bool getTrainReturned();
-  void setTrainReturned(bool train_returned);
+  void waitForPdo();
 
   int getEthercatCycleTime() const;
 

--- a/march_hardware/include/march_hardware/MarchRobot.h
+++ b/march_hardware/include/march_hardware/MarchRobot.h
@@ -50,6 +50,9 @@ public:
 
   bool isEthercatOperational();
 
+  bool getTrainReturned();
+  void setTrainReturned(bool train_returned);
+
   int getEthercatCycleTime() const;
 
   Joint getJoint(::std::string jointName);

--- a/march_hardware/src/EtherCAT/EthercatMaster.cpp
+++ b/march_hardware/src/EtherCAT/EthercatMaster.cpp
@@ -157,6 +157,7 @@ void EthercatMaster::ethercatLoop()
   {
     const auto begin_time = std::chrono::high_resolution_clock::now();
 
+    this->sendReceivePdo();
     monitorSlaveConnection();
 
     const auto end_time = std::chrono::high_resolution_clock::now();

--- a/march_hardware/src/EtherCAT/EthercatMaster.cpp
+++ b/march_hardware/src/EtherCAT/EthercatMaster.cpp
@@ -163,17 +163,18 @@ void EthercatMaster::ethercatLoop()
     const auto end_time = std::chrono::high_resolution_clock::now();
     const auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end_time - begin_time);
 
+    {
+      std::lock_guard<std::mutex> lock(this->wait_on_pdo_condition_mutex_);
+      this->pdo_received_ = true;
+    }
+    this->wait_on_pdo_condition_var_.notify_one();
+
     if (duration > cycle_time)
     {
       not_achieved_count++;
     }
     else
     {
-      {
-        std::lock_guard<std::mutex> lock(this->wait_on_pdo_condition_mutex_);
-        this->pdo_received_ = true;
-      }
-      this->wait_on_pdo_condition_var_.notify_one();
       std::this_thread::sleep_for(cycle_time - duration);
     }
     total_loops++;

--- a/march_hardware/src/EtherCAT/EthercatMaster.cpp
+++ b/march_hardware/src/EtherCAT/EthercatMaster.cpp
@@ -41,6 +41,16 @@ int EthercatMaster::getCycleTime() const
   return this->cycle_time_ms_;
 }
 
+bool EthercatMaster::getTrainReturned()
+{
+  return this->train_returned_;
+}
+
+void EthercatMaster::setTrainReturned(bool train_returned)
+{
+  this->train_returned_ = train_returned;
+}
+
 void EthercatMaster::start(std::vector<Joint>& joints)
 {
   this->ethercatMasterInitiation();
@@ -152,6 +162,8 @@ void EthercatMaster::ethercatLoop()
 
     this->sendReceivePdo();
     monitorSlaveConnection();
+
+    this->train_returned_ = true;
 
     const auto end_time = std::chrono::high_resolution_clock::now();
     const auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end_time - begin_time);

--- a/march_hardware/src/Joint.cpp
+++ b/march_hardware/src/Joint.cpp
@@ -199,6 +199,15 @@ bool Joint::canActuate()
   return this->allowActuation;
 }
 
+bool Joint::receivedDataUpdate()
+{
+  // We assume that the motor voltage cannot remain precisely constant.
+  float new_motor_volt = this->iMotionCube.getMotorVoltage();
+  bool data_updated = (new_motor_volt != this->previous_motor_volt_);
+  this->previous_motor_volt_ = new_motor_volt;
+  return data_updated;
+}
+
 void Joint::setNetNumber(int netNumber)
 {
   Joint::netNumber = netNumber;

--- a/march_hardware/src/MarchRobot.cpp
+++ b/march_hardware/src/MarchRobot.cpp
@@ -136,6 +136,16 @@ bool MarchRobot::isEthercatOperational()
   return ethercatMaster.isOperational();
 }
 
+bool MarchRobot::getTrainReturned()
+{
+  return this->ethercatMaster.getTrainReturned();
+}
+
+void MarchRobot::setTrainReturned(bool train_returned)
+{
+  return this->ethercatMaster.setTrainReturned(train_returned);
+}
+
 int MarchRobot::getEthercatCycleTime() const
 {
   return this->ethercatMaster.getCycleTime();

--- a/march_hardware/src/MarchRobot.cpp
+++ b/march_hardware/src/MarchRobot.cpp
@@ -136,14 +136,9 @@ bool MarchRobot::isEthercatOperational()
   return ethercatMaster.isOperational();
 }
 
-bool MarchRobot::getTrainReturned()
+void MarchRobot::waitForPdo()
 {
-  return this->ethercatMaster.getTrainReturned();
-}
-
-void MarchRobot::setTrainReturned(bool train_returned)
-{
-  return this->ethercatMaster.setTrainReturned(train_returned);
+  this->ethercatMaster.waitForPdo();
 }
 
 int MarchRobot::getEthercatCycleTime() const

--- a/march_hardware_interface/include/march_hardware_interface/march_hardware_interface.h
+++ b/march_hardware_interface/include/march_hardware_interface/march_hardware_interface.h
@@ -68,8 +68,7 @@ public:
    */
   int getEthercatCycleTime() const;
 
-  bool getTrainReturned();
-  void setTrainReturned(bool train_returned);
+  void waitForPdo();
 
 private:
   /**

--- a/march_hardware_interface/include/march_hardware_interface/march_hardware_interface.h
+++ b/march_hardware_interface/include/march_hardware_interface/march_hardware_interface.h
@@ -68,6 +68,9 @@ public:
    */
   int getEthercatCycleTime() const;
 
+  bool getTrainReturned();
+  void setTrainReturned(bool train_returned);
+
 private:
   /**
    * Uses the num_joints_ member to resize all vectors

--- a/march_hardware_interface/launch/hardware.launch
+++ b/march_hardware_interface/launch/hardware.launch
@@ -1,10 +1,5 @@
 <launch>
     <arg name="robot" default="march4" doc="The robot to run. Can be: march3, march4, test_joint_linear, test_joint_rotational."/>
-    <arg name="control_loop_multiplier" default="1"
-         doc="Multiplier for the duration of the control loop cycle time compared
-              to the ethercat cycle time. This must be a positive integer and
-              always assures that the control loop cycle time is a multiple of
-              the ethercat cycle time."/>
 
     <rosparam file="$(find march_hardware_interface)/config/$(arg robot)/controllers.yaml" command="load"/>
 
@@ -25,8 +20,6 @@
                 args="$(arg robot)"
                 output="screen"
                 required="true"
-        >
-            <param name="control_loop_multiplier" value="$(arg control_loop_multiplier)"/>
-        </node>
+        />
     </group>
 </launch>

--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -192,14 +192,9 @@ void MarchHardwareInterface::validate()
   }
 }
 
-bool MarchHardwareInterface::getTrainReturned()
+void MarchHardwareInterface::waitForPdo()
 {
-  return this->march_robot_->getTrainReturned();
-}
-
-void MarchHardwareInterface::setTrainReturned(bool train_returned)
-{
-  return this->march_robot_->setTrainReturned(train_returned);
+  this->march_robot_->waitForPdo();
 }
 
 void MarchHardwareInterface::read(const ros::Time& /* time */, const ros::Duration& elapsed_time)

--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -201,26 +201,34 @@ void MarchHardwareInterface::read(const ros::Time& /* time */, const ros::Durati
 {
   for (size_t i = 0; i < num_joints_; i++)
   {
-    const double old_relative_position = relative_joint_position_[i];
-
     march::Joint joint = march_robot_->getJoint(joint_names_[i]);
-
-    joint_position_[i] = joint.getAngleRadAbsolute();
-    relative_joint_position_[i] = joint.getAngleRadMostPrecise();
-
-    if (joint.hasTemperatureGES())
+    if (joint.receivedDataUpdate())
     {
-      joint_temperature_[i] = joint.getTemperature();
+      const double old_relative_position = relative_joint_position_[i];
+
+      joint_position_[i] = joint.getAngleRadAbsolute();
+      relative_joint_position_[i] = joint.getAngleRadMostPrecise();
+
+      if (joint.hasTemperatureGES())
+      {
+        joint_temperature_[i] = joint.getTemperature();
+      }
+
+      // Get velocity from encoder position
+      const double joint_velocity = (relative_joint_position_[i] - old_relative_position) / elapsed_time.toSec();
+
+      // Apply exponential smoothing to velocity obtained from encoder with
+      joint_velocity_[i] =
+          MarchHardwareInterface::ALPHA * joint_velocity + (1 - MarchHardwareInterface::ALPHA) * joint_velocity_[i];
+
+      joint_effort_[i] = joint.getTorque();
     }
-
-    // Get velocity from encoder position
-    const double joint_velocity = (relative_joint_position_[i] - old_relative_position) / elapsed_time.toSec();
-
-    // Apply exponential smoothing to velocity obtained from encoder with
-    joint_velocity_[i] =
-        MarchHardwareInterface::ALPHA * joint_velocity + (1 - MarchHardwareInterface::ALPHA) * joint_velocity_[i];
-
-    joint_effort_[i] = joint.getTorque();
+    else
+    {
+      // If no update was received, assume constant velocity.
+      joint_position_[i] += joint_velocity_[i] * elapsed_time.toSec();
+      relative_joint_position_[i] = joint_velocity_[i] * elapsed_time.toSec();
+    }
   }
 
   this->updateIMotionCubeState();

--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -192,6 +192,16 @@ void MarchHardwareInterface::validate()
   }
 }
 
+bool MarchHardwareInterface::getTrainReturned()
+{
+  return this->march_robot_->getTrainReturned();
+}
+
+void MarchHardwareInterface::setTrainReturned(bool train_returned)
+{
+  return this->march_robot_->setTrainReturned(train_returned);
+}
+
 void MarchHardwareInterface::read(const ros::Time& /* time */, const ros::Duration& elapsed_time)
 {
   for (size_t i = 0; i < num_joints_; i++)

--- a/march_hardware_interface/src/march_hardware_interface_node.cpp
+++ b/march_hardware_interface/src/march_hardware_interface_node.cpp
@@ -41,11 +41,8 @@ int main(int argc, char** argv)
     return 1;
   }
 
-  ros::Rate rate(
-      ros::Duration(march.getEthercatCycleTime() * ros::param::param<int>("~control_loop_multiplier", 1) / 1000.0));
-
   controller_manager::ControllerManager controller_manager(&march, nh);
-  ros::Time last_update_time = ros::Time::now() - rate.expectedCycleTime();
+  ros::Time last_update_time = ros::Time::now() - ros::Duration(march.getEthercatCycleTime() / 1000.0);
 
   while (ros::ok())
   {
@@ -61,8 +58,6 @@ int main(int argc, char** argv)
       march.validate();
       controller_manager.update(now, elapsed_time);
       march.write(now, elapsed_time);
-
-      rate.sleep();
     }
     catch (const std::exception& e)
     {

--- a/march_hardware_interface/src/march_hardware_interface_node.cpp
+++ b/march_hardware_interface/src/march_hardware_interface_node.cpp
@@ -49,18 +49,19 @@ int main(int argc, char** argv)
 
   while (ros::ok())
   {
-    const ros::Time now = ros::Time::now();
     try
     {
-      if (march.getTrainReturned())
-      {
-        march.setTrainReturned(false);
-        march.read(now, now - last_update_time);
-        last_update_time = now;
-        march.validate();
-        controller_manager.update(now, rate.expectedCycleTime());
-        march.write(now, rate.expectedCycleTime());
-      }
+      march.waitForPdo();
+
+      const ros::Time now = ros::Time::now();
+      ros::Duration elapsed_time = now - last_update_time;
+      last_update_time = now;
+
+      march.read(now, elapsed_time);
+      march.validate();
+      controller_manager.update(now, elapsed_time);
+      march.write(now, elapsed_time);
+
       rate.sleep();
     }
     catch (const std::exception& e)


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

Closes PM-338

## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->

The EthercatMaster now signals the march_hardware_interface_node, which then  updates the controller. In addition, the read method of the march_hardware_interface checks for every joint if the data of that joint has been updated. If it has not, it keeps velocity constant and updates positions accordingly. 

## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->

* Ethercat master uses std::condition_variable to send signal when PDO is received
* march_hardware_interface_node only updates controller when the signal is received
* Velocity is kept constant for every joint that did not receive an update.
* Use actual time since last update as input for velocity instead of expectedCycleTime

<!-- Please don't forget to request for reviews -->
