### PR TITLE
Fix: dependency injection

### DIFF
--- a/march_hardware/include/march_hardware/IMotionCube.h
+++ b/march_hardware/include/march_hardware/IMotionCube.h
@@ -97,7 +97,7 @@ private:
 
   // Use of smart pointers are necessary here to make dependency injection
   // possible and thus allow for mocking the encoders. A unique pointer is
-  // is chosen since the IMotionCube should be the owner and the encoders
+  // chosen since the IMotionCube should be the owner and the encoders
   // do not need to be passed around.
   std::unique_ptr<AbsoluteEncoder> absolute_encoder_;
   std::unique_ptr<IncrementalEncoder> incremental_encoder_;

--- a/march_hardware/include/march_hardware/IMotionCube.h
+++ b/march_hardware/include/march_hardware/IMotionCube.h
@@ -58,11 +58,11 @@ public:
 
   void setControlWord(uint16_t control_word);
 
-  void actuateRad(double target_rad);
-  void actuateTorque(int16_t target_torque);
+  virtual void actuateRad(double target_rad);
+  virtual void actuateTorque(int16_t target_torque);
 
   void goToTargetState(IMotionCubeTargetState target_state);
-  void goToOperationEnabled();
+  virtual void goToOperationEnabled();
 
   /** @brief Override comparison operator */
   friend bool operator==(const IMotionCube& lhs, const IMotionCube& rhs)

--- a/march_hardware/include/march_hardware/IMotionCube.h
+++ b/march_hardware/include/march_hardware/IMotionCube.h
@@ -32,7 +32,11 @@ public:
   IMotionCube(int slave_index, std::unique_ptr<AbsoluteEncoder> absolute_encoder,
               std::unique_ptr<IncrementalEncoder> incremental_encoder, ActuationMode actuation_mode);
 
-  ~IMotionCube() = default;
+  ~IMotionCube() noexcept override = default;
+
+  /* Delete copy constructor/assignment since the unique_ptrs cannot be copied */
+  IMotionCube(const IMotionCube&) = delete;
+  IMotionCube& operator=(const IMotionCube&) = delete;
 
   void writeInitialSDOs(int cycle_time) override;
 

--- a/march_hardware/include/march_hardware/IMotionCube.h
+++ b/march_hardware/include/march_hardware/IMotionCube.h
@@ -67,15 +67,15 @@ public:
   /** @brief Override comparison operator */
   friend bool operator==(const IMotionCube& lhs, const IMotionCube& rhs)
   {
-    return lhs.slaveIndex == rhs.slaveIndex && lhs.absolute_encoder_ == rhs.absolute_encoder_ &&
-           lhs.incremental_encoder_ == rhs.incremental_encoder_;
+    return lhs.slaveIndex == rhs.slaveIndex && *lhs.absolute_encoder_ == *rhs.absolute_encoder_ &&
+           *lhs.incremental_encoder_ == *rhs.incremental_encoder_;
   }
   /** @brief Override stream operator for clean printing */
   friend std::ostream& operator<<(std::ostream& os, const IMotionCube& imc)
   {
     return os << "slaveIndex: " << imc.slaveIndex << ", "
-              << "incrementalEncoder: " << imc.incremental_encoder_.get() << ", "
-              << "absoluteEncoder: " << imc.absolute_encoder_.get();
+              << "incrementalEncoder: " << *imc.incremental_encoder_ << ", "
+              << "absoluteEncoder: " << *imc.absolute_encoder_;
   }
 
   constexpr static double MAX_TARGET_DIFFERENCE = 0.393;

--- a/march_hardware/include/march_hardware/Joint.h
+++ b/march_hardware/include/march_hardware/Joint.h
@@ -27,6 +27,12 @@ private:
 public:
   explicit Joint(std::unique_ptr<IMotionCube> imc);
 
+  virtual ~Joint() noexcept = default;
+
+  /* Delete copy constructor/assignment since the unique_ptr cannot be copied */
+  Joint(const Joint&) = delete;
+  Joint& operator=(const Joint&) = delete;
+
   void initialize(int ecatCycleTime);
   void prepareActuation();
   void shutdown();

--- a/march_hardware/include/march_hardware/Joint.h
+++ b/march_hardware/include/march_hardware/Joint.h
@@ -16,16 +16,23 @@ namespace march
 {
 class Joint
 {
-private:
-  std::string name;
-  // Set this number via the hardware builder
-  int netNumber;
-  bool allowActuation;
-  std::unique_ptr<IMotionCube> iMotionCube;
-  TemperatureGES temperatureGES;
-
 public:
-  explicit Joint(std::unique_ptr<IMotionCube> imc);
+  /**
+   * Initializes a Joint without motor controller and temperature slave.
+   * Actuation will be disabled.
+   */
+  Joint(std::string name, int net_number);
+
+  /**
+   * Initializes a Joint with motor controller and without temperature slave.
+   */
+  Joint(std::string name, int net_number, bool allow_actuation, std::unique_ptr<IMotionCube> imc);
+
+  /**
+   * Initializes a Joint with motor controller and temperature slave.
+   */
+  Joint(std::string name, int net_number, bool allow_actuation, std::unique_ptr<IMotionCube> imc,
+        std::unique_ptr<TemperatureGES> temperature_ges);
 
   virtual ~Joint() noexcept = default;
 
@@ -33,12 +40,11 @@ public:
   Joint(const Joint&) = delete;
   Joint& operator=(const Joint&) = delete;
 
-  void initialize(int ecatCycleTime);
+  void initialize(int cycle_time);
   void prepareActuation();
-  void shutdown();
 
-  void actuateRad(double targetPositionRad);
-  void actuateTorque(int16_t targetTorque);
+  void actuateRad(double target_position);
+  void actuateTorque(int16_t target_torque);
 
   double getAngleRadAbsolute();
   double getAngleRadIncremental();
@@ -49,25 +55,23 @@ public:
   float getTemperature();
   IMotionCubeState getIMotionCubeState();
 
-  std::string getName();
-  int getTemperatureGESSlaveIndex();
-  int getIMotionCubeSlaveIndex();
-  int getNetNumber()
-  {
-    return netNumber;
-  }
+  std::string getName() const;
+  int getTemperatureGESSlaveIndex() const;
+  int getIMotionCubeSlaveIndex() const;
+  int getNetNumber() const;
 
   ActuationMode getActuationMode() const;
 
-  bool hasIMotionCube();
-  bool hasTemperatureGES();
-  bool canActuate();
+  bool hasIMotionCube() const;
+  bool hasTemperatureGES() const;
+  bool canActuate() const;
+  void setAllowActuation(bool allow_actuation);
 
   /** @brief Override comparison operator */
   friend bool operator==(const Joint& lhs, const Joint& rhs)
   {
-    return lhs.name == rhs.name && lhs.iMotionCube == rhs.iMotionCube && lhs.temperatureGES == rhs.temperatureGES &&
-           lhs.allowActuation == rhs.allowActuation &&
+    return lhs.name_ == rhs.name_ && lhs.imc_ == rhs.imc_ && lhs.temperature_ges_ == rhs.temperature_ges_ &&
+           lhs.allow_actuation_ == rhs.allow_actuation_ &&
            lhs.getActuationMode().getValue() == rhs.getActuationMode().getValue();
   }
 
@@ -78,17 +82,20 @@ public:
   /** @brief Override stream operator for clean printing */
   friend ::std::ostream& operator<<(std::ostream& os, const Joint& joint)
   {
-    return os << "name: " << joint.name << ", "
+    return os << "name: " << joint.name_ << ", "
               << "ActuationMode: " << joint.getActuationMode().toString() << ", "
-              << "allowActuation: " << joint.allowActuation << ", "
-              << "imotioncube: " << joint.iMotionCube.get() << ","
-              << "temperatureges: " << joint.temperatureGES;
+              << "allowActuation: " << joint.allow_actuation_ << ", "
+              << "imotioncube: " << joint.imc_.get() << ","
+              << "temperatureges: " << joint.temperature_ges_.get();
   }
 
-  void setName(const std::string& name);
-  void setAllowActuation(bool allowActuation);
-  void setTemperatureGes(const TemperatureGES& temperatureGes);
-  void setNetNumber(int netNumber);
+private:
+  const std::string name_;
+  const int net_number_;
+  bool allow_actuation_ = false;
+
+  std::unique_ptr<IMotionCube> imc_ = nullptr;
+  std::unique_ptr<TemperatureGES> temperature_ges_ = nullptr;
 };
 
 }  // namespace march

--- a/march_hardware/include/march_hardware/Joint.h
+++ b/march_hardware/include/march_hardware/Joint.h
@@ -2,7 +2,9 @@
 #ifndef MARCH_HARDWARE_JOINT_H
 #define MARCH_HARDWARE_JOINT_H
 
+#include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <march_hardware/IMotionCube.h>
@@ -19,13 +21,11 @@ private:
   // Set this number via the hardware builder
   int netNumber;
   bool allowActuation;
-  IMotionCube iMotionCube;
+  std::unique_ptr<IMotionCube> iMotionCube;
   TemperatureGES temperatureGES;
 
 public:
-  explicit Joint(const IMotionCube& imc) : name(""), netNumber(-1), allowActuation(false), iMotionCube(imc)
-  {
-  }
+  explicit Joint(std::unique_ptr<IMotionCube> imc);
 
   void initialize(int ecatCycleTime);
   void prepareActuation();
@@ -75,7 +75,7 @@ public:
     return os << "name: " << joint.name << ", "
               << "ActuationMode: " << joint.getActuationMode().toString() << ", "
               << "allowActuation: " << joint.allowActuation << ", "
-              << "imotioncube: " << joint.iMotionCube << ","
+              << "imotioncube: " << joint.iMotionCube.get() << ","
               << "temperatureges: " << joint.temperatureGES;
   }
 

--- a/march_hardware/include/march_hardware/Joint.h
+++ b/march_hardware/include/march_hardware/Joint.h
@@ -40,6 +40,10 @@ public:
   Joint(const Joint&) = delete;
   Joint& operator=(const Joint&) = delete;
 
+  /* Delete move assignment since string cannot be move assigned */
+  Joint(Joint&&) = default;
+  Joint& operator=(Joint&&) = delete;
+
   void initialize(int cycle_time);
   void prepareActuation();
 
@@ -70,7 +74,9 @@ public:
   /** @brief Override comparison operator */
   friend bool operator==(const Joint& lhs, const Joint& rhs)
   {
-    return lhs.name_ == rhs.name_ && lhs.imc_ == rhs.imc_ && lhs.temperature_ges_ == rhs.temperature_ges_ &&
+    return lhs.name_ == rhs.name_ && ((lhs.imc_ && rhs.imc_ && *lhs.imc_ == *rhs.imc_) || (!lhs.imc_ && !rhs.imc_)) &&
+           ((lhs.temperature_ges_ && rhs.temperature_ges_ && *lhs.temperature_ges_ == *rhs.temperature_ges_) ||
+            (!lhs.temperature_ges_ && !rhs.temperature_ges_)) &&
            lhs.allow_actuation_ == rhs.allow_actuation_ &&
            lhs.getActuationMode().getValue() == rhs.getActuationMode().getValue();
   }
@@ -82,11 +88,30 @@ public:
   /** @brief Override stream operator for clean printing */
   friend ::std::ostream& operator<<(std::ostream& os, const Joint& joint)
   {
-    return os << "name: " << joint.name_ << ", "
-              << "ActuationMode: " << joint.getActuationMode().toString() << ", "
-              << "allowActuation: " << joint.allow_actuation_ << ", "
-              << "imotioncube: " << joint.imc_.get() << ","
-              << "temperatureges: " << joint.temperature_ges_.get();
+    os << "name: " << joint.name_ << ", "
+       << "ActuationMode: " << joint.getActuationMode().toString() << ", "
+       << "allowActuation: " << joint.allow_actuation_ << ", "
+       << "imotioncube: ";
+    if (joint.imc_)
+    {
+      os << *joint.imc_;
+    }
+    else
+    {
+      os << "none";
+    }
+
+    os << ", temperatureges: ";
+    if (joint.temperature_ges_)
+    {
+      os << *joint.temperature_ges_;
+    }
+    else
+    {
+      os << "none";
+    }
+
+    return os;
   }
 
 private:

--- a/march_hardware/include/march_hardware/MarchRobot.h
+++ b/march_hardware/include/march_hardware/MarchRobot.h
@@ -52,7 +52,7 @@ public:
 
   int getEthercatCycleTime() const;
 
-  Joint getJoint(::std::string jointName);
+  Joint& getJoint(::std::string jointName);
 
   PowerDistributionBoard& getPowerDistributionBoard();
   const PowerDistributionBoard& getPowerDistributionBoard() const;
@@ -68,8 +68,8 @@ public:
     }
     for (unsigned int i = 0; i < lhs.jointList.size(); i++)
     {
-      const march::Joint lhsJoint = lhs.jointList.at(i);
-      const march::Joint rhsJoint = rhs.jointList.at(i);
+      const march::Joint& lhsJoint = lhs.jointList.at(i);
+      const march::Joint& rhsJoint = rhs.jointList.at(i);
       if (lhsJoint != rhsJoint)
       {
         return false;

--- a/march_hardware/include/march_hardware/Slave.h
+++ b/march_hardware/include/march_hardware/Slave.h
@@ -28,7 +28,7 @@ public:
     slaveIndex = -1;
   };
 
-  ~Slave() = default;
+  virtual ~Slave() noexcept = default;
 
   virtual void writeInitialSDOs(int /* cycle_time */)
   {

--- a/march_hardware/include/march_hardware/TemperatureGES.h
+++ b/march_hardware/include/march_hardware/TemperatureGES.h
@@ -22,6 +22,8 @@ public:
     slaveIndex = -1;
   };
 
+  ~TemperatureGES() noexcept override = default;
+
   float getTemperature() override;
 
   /** @brief Override comparison operator */

--- a/march_hardware/include/march_hardware/TemperatureSensor.h
+++ b/march_hardware/include/march_hardware/TemperatureSensor.h
@@ -7,6 +7,8 @@ namespace march
 class TemperatureSensor
 {
 public:
+  virtual ~TemperatureSensor() noexcept = default;
+
   virtual float getTemperature() = 0;
 };
 }  // namespace march

--- a/march_hardware/include/march_hardware/encoder/AbsoluteEncoder.h
+++ b/march_hardware/include/march_hardware/encoder/AbsoluteEncoder.h
@@ -14,6 +14,8 @@ public:
   AbsoluteEncoder(size_t number_of_bits, int32_t lower_limit_iu, int32_t upper_limit_iu, double lower_limit_rad,
                   double upper_limit_rad, double lower_soft_limit_rad, double upper_soft_limit_rad);
 
+  ~AbsoluteEncoder() noexcept override = default;
+
   double toRad(int32_t iu) const override;
 
   /**

--- a/march_hardware/include/march_hardware/encoder/AbsoluteEncoder.h
+++ b/march_hardware/include/march_hardware/encoder/AbsoluteEncoder.h
@@ -16,7 +16,7 @@ public:
 
   double toRad(int32_t iu) const override;
 
-  /*
+  /**
    * Converts radians to encoder Internal Units (IU).
    */
   int32_t fromRad(double rad) const;

--- a/march_hardware/include/march_hardware/encoder/Encoder.h
+++ b/march_hardware/include/march_hardware/encoder/Encoder.h
@@ -13,6 +13,8 @@ class Encoder
 public:
   explicit Encoder(size_t number_of_bits);
 
+  virtual ~Encoder() noexcept = default;
+
   /**
    * Reads out the encoder from the slave and returns the value in Internal Units (IU).
    * @param byte_offset the byte offset in the slave register for the IU position

--- a/march_hardware/include/march_hardware/encoder/Encoder.h
+++ b/march_hardware/include/march_hardware/encoder/Encoder.h
@@ -13,21 +13,21 @@ class Encoder
 public:
   explicit Encoder(size_t number_of_bits);
 
-  /*
+  /**
    * Reads out the encoder from the slave and returns the value in Internal Units (IU).
    * @param byte_offset the byte offset in the slave register for the IU position
    * @returns The current position of the encoder in Internal Units (IU)
    */
   int32_t getAngleIU(uint8_t byte_offset) const;
 
-  /*
+  /**
    * Reads out the encoder from the slave and transforms the result to radians.
    * @param byte_offset the byte offset in the slave register for the IU position
    * @returns The current position of the encoder in radians
    */
   double getAngleRad(uint8_t byte_offset) const;
 
-  /*
+  /**
    * Converts encoder Internal Units (IU) to radians.
    * This is a pure virtual function and must be implemented by subclasses,
    * since each type of encoder has a different way of calculating radians.
@@ -45,7 +45,7 @@ public:
   static constexpr double PI_2 = 2 * M_PI;
 
 private:
-  /*
+  /**
    * Returns the total number of positions possible on an encoder
    * with the given amount of bits.
    * @param number_of_bits The resolution of the encoder

--- a/march_hardware/include/march_hardware/encoder/IncrementalEncoder.h
+++ b/march_hardware/include/march_hardware/encoder/IncrementalEncoder.h
@@ -13,6 +13,8 @@ class IncrementalEncoder : public Encoder
 public:
   IncrementalEncoder(size_t number_of_bits, double transmission);
 
+  ~IncrementalEncoder() noexcept override = default;
+
   double toRad(int32_t iu) const override;
   double getTransmission() const;
 

--- a/march_hardware/src/IMotionCube.cpp
+++ b/march_hardware/src/IMotionCube.cpp
@@ -6,25 +6,32 @@
 #include "march_hardware/EtherCAT/EthercatIO.h"
 
 #include <bitset>
+#include <memory>
+#include <stdexcept>
 #include <string>
 #include <unistd.h>
+#include <utility>
 
 #include <ros/ros.h>
 
 namespace march
 {
-IMotionCube::IMotionCube(int slave_index, AbsoluteEncoder absolute_encoder, IncrementalEncoder incremental_encoder,
-                         ActuationMode actuation_mode)
+IMotionCube::IMotionCube(int slave_index, std::unique_ptr<AbsoluteEncoder> absolute_encoder,
+                         std::unique_ptr<IncrementalEncoder> incremental_encoder, ActuationMode actuation_mode)
   : Slave(slave_index)
-  , absolute_encoder_(absolute_encoder)
-  , incremental_encoder_(incremental_encoder)
+  , absolute_encoder_(std::move(absolute_encoder))
+  , incremental_encoder_(std::move(incremental_encoder))
   , actuation_mode_(actuation_mode)
 {
-  this->absolute_encoder_.setSlaveIndex(slave_index);
-  this->incremental_encoder_.setSlaveIndex(slave_index);
+  if (!this->absolute_encoder_ || !this->incremental_encoder_)
+  {
+    throw std::invalid_argument("Incremental or absolute encoder cannot be nullptr");
+  }
+  this->absolute_encoder_->setSlaveIndex(slave_index);
+  this->incremental_encoder_->setSlaveIndex(slave_index);
   this->is_incremental_more_precise_ =
-      (this->incremental_encoder_.getTotalPositions() * this->incremental_encoder_.getTransmission() >
-       this->absolute_encoder_.getTotalPositions() * 10);
+      (this->incremental_encoder_->getTotalPositions() * this->incremental_encoder_->getTransmission() >
+       this->absolute_encoder_->getTotalPositions() * 10);
   // Multiply by ten to ensure the rotational joints keep using absolute encoders. These are somehow more accurate
   // even though they theoretically shouldn't be.
 }
@@ -38,9 +45,9 @@ void IMotionCube::writeInitialSDOs(int cycle_time)
                                                                              "as it has actuation mode of unknown");
   }
 
-  mapMisoPDOs();
-  mapMosiPDOs();
-  writeInitialSettings(cycle_time);
+  this->mapMisoPDOs();
+  this->mapMosiPDOs();
+  this->writeInitialSettings(cycle_time);
 }
 
 // Map Process Data Object (PDO) for by sending SDOs to the IMC
@@ -78,10 +85,10 @@ void IMotionCube::writeInitialSettings(uint8_t cycle_time)
   int mode_of_op = sdo_bit8(slaveIndex, 0x6060, 0, this->actuation_mode_.toModeNumber());
 
   // position limit -- min position
-  int min_pos_lim = sdo_bit32(slaveIndex, 0x607D, 1, this->absolute_encoder_.getLowerSoftLimitIU());
+  int min_pos_lim = sdo_bit32(slaveIndex, 0x607D, 1, this->absolute_encoder_->getLowerSoftLimitIU());
 
   // position limit -- max position
-  int max_pos_lim = sdo_bit32(slaveIndex, 0x607D, 2, this->absolute_encoder_.getUpperSoftLimitIU());
+  int max_pos_lim = sdo_bit32(slaveIndex, 0x607D, 2, this->absolute_encoder_->getUpperSoftLimitIU());
 
   // Quick stop option
   int stop_opt = sdo_bit16(slaveIndex, 0x605A, 0, 6);
@@ -118,16 +125,17 @@ void IMotionCube::actuateRad(double target_rad)
                                    "Target %f exceeds max difference of %f from current %f for slave %d", target_rad,
                                    MAX_TARGET_DIFFERENCE, this->getAngleRadAbsolute(), this->slaveIndex);
   }
-  this->actuateIU(this->absolute_encoder_.fromRad(target_rad));
+  this->actuateIU(this->absolute_encoder_->fromRad(target_rad));
 }
 
 void IMotionCube::actuateIU(int32_t target_iu)
 {
-  if (!this->absolute_encoder_.isValidTargetIU(this->getAngleIUAbsolute(), target_iu))
+  if (!this->absolute_encoder_->isValidTargetIU(this->getAngleIUAbsolute(), target_iu))
   {
-    throw error::HardwareException(
-        error::ErrorType::INVALID_ACTUATE_POSITION, "Position %i is invalid for slave %d. (%d, %d)", target_iu,
-        this->slaveIndex, this->absolute_encoder_.getLowerSoftLimitIU(), this->absolute_encoder_.getUpperSoftLimitIU());
+    throw error::HardwareException(error::ErrorType::INVALID_ACTUATE_POSITION,
+                                   "Position %i is invalid for slave %d. (%d, %d)", target_iu, this->slaveIndex,
+                                   this->absolute_encoder_->getLowerSoftLimitIU(),
+                                   this->absolute_encoder_->getUpperSoftLimitIU());
   }
 
   bit32 target_position = { .i = target_iu };
@@ -166,7 +174,7 @@ double IMotionCube::getAngleRadAbsolute()
   {
     ROS_WARN_THROTTLE(10, "Invalid use of encoders, you're not in the correct state.");
   }
-  return this->absolute_encoder_.getAngleRad(this->miso_byte_offsets_.at(IMCObjectName::ActualPosition));
+  return this->absolute_encoder_->getAngleRad(this->miso_byte_offsets_.at(IMCObjectName::ActualPosition));
 }
 
 double IMotionCube::getAngleRadIncremental()
@@ -176,7 +184,7 @@ double IMotionCube::getAngleRadIncremental()
   {
     ROS_WARN_THROTTLE(10, "Invalid use of encoders, you're not in the correct state.");
   }
-  return this->incremental_encoder_.getAngleRad(this->miso_byte_offsets_.at(IMCObjectName::MotorPosition));
+  return this->incremental_encoder_->getAngleRad(this->miso_byte_offsets_.at(IMCObjectName::MotorPosition));
 }
 
 double IMotionCube::getAngleRadMostPrecise()
@@ -199,12 +207,12 @@ int16_t IMotionCube::getTorque()
 
 int32_t IMotionCube::getAngleIUAbsolute()
 {
-  return this->absolute_encoder_.getAngleIU(this->miso_byte_offsets_.at(IMCObjectName::ActualPosition));
+  return this->absolute_encoder_->getAngleIU(this->miso_byte_offsets_.at(IMCObjectName::ActualPosition));
 }
 
 int IMotionCube::getAngleIUIncremental()
 {
-  return this->incremental_encoder_.getAngleIU(this->miso_byte_offsets_.at(IMCObjectName::MotorPosition));
+  return this->incremental_encoder_->getAngleIU(this->miso_byte_offsets_.at(IMCObjectName::MotorPosition));
 }
 
 uint16_t IMotionCube::getStatusWord()
@@ -293,13 +301,13 @@ void IMotionCube::goToOperationEnabled()
                                    "Encoder of IMotionCube with slave index %d has reset. Read angle %d IU",
                                    this->slaveIndex, angle);
   }
-  else if (!this->absolute_encoder_.isWithinHardLimitsIU(angle))
+  else if (!this->absolute_encoder_->isWithinHardLimitsIU(angle))
   {
     throw error::HardwareException(error::ErrorType::OUTSIDE_HARD_LIMITS,
                                    "Joint with slave index %d is outside hard limits (read value %d IU, limits from %d "
                                    "IU to %d IU)",
-                                   this->slaveIndex, angle, this->absolute_encoder_.getLowerHardLimitIU(),
-                                   this->absolute_encoder_.getUpperHardLimitIU());
+                                   this->slaveIndex, angle, this->absolute_encoder_->getLowerHardLimitIU(),
+                                   this->absolute_encoder_->getUpperHardLimitIU());
   }
 
   if (this->actuation_mode_ == ActuationMode::position)

--- a/march_hardware/src/IMotionCube.cpp
+++ b/march_hardware/src/IMotionCube.cpp
@@ -133,7 +133,7 @@ void IMotionCube::actuateIU(int32_t target_iu)
   if (!this->absolute_encoder_->isValidTargetIU(this->getAngleIUAbsolute(), target_iu))
   {
     throw error::HardwareException(error::ErrorType::INVALID_ACTUATE_POSITION,
-                                   "Position %i is invalid for slave %d. (%d, %d)", target_iu, this->slaveIndex,
+                                   "Position %d is invalid for slave %d. (%d, %d)", target_iu, this->slaveIndex,
                                    this->absolute_encoder_->getLowerSoftLimitIU(),
                                    this->absolute_encoder_->getUpperSoftLimitIU());
   }

--- a/march_hardware/src/Joint.cpp
+++ b/march_hardware/src/Joint.cpp
@@ -12,17 +12,12 @@
 
 namespace march
 {
-Joint::Joint(std::string name, int net_number)
-  : name_(std::move(name))
-  , net_number_(net_number)
+Joint::Joint(std::string name, int net_number) : name_(std::move(name)), net_number_(net_number)
 {
 }
 
 Joint::Joint(std::string name, int net_number, bool allow_actuation, std::unique_ptr<IMotionCube> imc)
-  : name_(std::move(name))
-  , net_number_(net_number)
-  , allow_actuation_(allow_actuation)
-  , imc_(std::move(imc))
+  : name_(std::move(name)), net_number_(net_number), allow_actuation_(allow_actuation), imc_(std::move(imc))
 {
 }
 
@@ -50,7 +45,7 @@ void Joint::initialize(int cycle_time)
 
 void Joint::prepareActuation()
 {
-  if (!this->allow_actuation_)
+  if (!this->canActuate())
   {
     throw error::HardwareException(error::ErrorType::NOT_ALLOWED_TO_ACTUATE, "Failed to prepare joint %s for actuation",
                                    this->name_.c_str());
@@ -62,7 +57,7 @@ void Joint::prepareActuation()
 
 void Joint::actuateRad(double target_position)
 {
-  if (!this->allow_actuation_)
+  if (!this->canActuate())
   {
     throw error::HardwareException(error::ErrorType::NOT_ALLOWED_TO_ACTUATE, "Joint %s is not allowed to actuate",
                                    this->name_.c_str());
@@ -102,7 +97,7 @@ double Joint::getAngleRadMostPrecise()
 
 void Joint::actuateTorque(int16_t target_torque)
 {
-  if (!this->allow_actuation_)
+  if (!this->canActuate())
   {
     throw error::HardwareException(error::ErrorType::NOT_ALLOWED_TO_ACTUATE, "Joint %s is not allowed to actuate",
                                    this->name_.c_str());
@@ -145,7 +140,7 @@ float Joint::getTemperature()
   if (!this->hasTemperatureGES())
   {
     ROS_WARN("[%s] Has no temperature sensor", this->name_.c_str());
-    return -1;
+    return -1.0;
   }
   return this->temperature_ges_->getTemperature();
 }
@@ -219,7 +214,7 @@ bool Joint::hasTemperatureGES() const
 
 bool Joint::canActuate() const
 {
-  return this->allow_actuation_;
+  return this->allow_actuation_ && this->hasIMotionCube();
 }
 
 ActuationMode Joint::getActuationMode() const

--- a/march_hardware/src/Joint.cpp
+++ b/march_hardware/src/Joint.cpp
@@ -12,212 +12,219 @@
 
 namespace march
 {
-Joint::Joint(std::unique_ptr<IMotionCube> imc)
-  : name(""), netNumber(-1), allowActuation(false), iMotionCube(std::move(imc))
+Joint::Joint(std::string name, int net_number)
+  : name_(std::move(name))
+  , net_number_(net_number)
 {
-  if (!this->iMotionCube)
-  {
-    throw std::invalid_argument("IMotionCube argument cannot be nullptr");
-  }
 }
 
-void Joint::initialize(int ecatCycleTime)
+Joint::Joint(std::string name, int net_number, bool allow_actuation, std::unique_ptr<IMotionCube> imc)
+  : name_(std::move(name))
+  , net_number_(net_number)
+  , allow_actuation_(allow_actuation)
+  , imc_(std::move(imc))
 {
-  if (hasIMotionCube())
+}
+
+Joint::Joint(std::string name, int net_number, bool allow_actuation, std::unique_ptr<IMotionCube> imc,
+             std::unique_ptr<TemperatureGES> temperature_ges)
+  : name_(std::move(name))
+  , net_number_(net_number)
+  , allow_actuation_(allow_actuation)
+  , imc_(std::move(imc))
+  , temperature_ges_(std::move(temperature_ges))
+{
+}
+
+void Joint::initialize(int cycle_time)
+{
+  if (this->hasIMotionCube())
   {
-    iMotionCube->writeInitialSDOs(ecatCycleTime);
+    this->imc_->writeInitialSDOs(cycle_time);
   }
-  if (hasTemperatureGES())
+  if (this->hasTemperatureGES())
   {
-    temperatureGES.writeInitialSDOs(ecatCycleTime);
+    this->temperature_ges_->writeInitialSDOs(cycle_time);
   }
 }
 
 void Joint::prepareActuation()
 {
-  if (!this->allowActuation)
+  if (!this->allow_actuation_)
   {
     throw error::HardwareException(error::ErrorType::NOT_ALLOWED_TO_ACTUATE, "Failed to prepare joint %s for actuation",
-                                   this->name.c_str());
+                                   this->name_.c_str());
   }
-  ROS_INFO("[%s] Preparing for actuation", this->name.c_str());
-  this->iMotionCube->goToOperationEnabled();
-  ROS_INFO("[%s] Successfully prepared for actuation", this->name.c_str());
+  ROS_INFO("[%s] Preparing for actuation", this->name_.c_str());
+  this->imc_->goToOperationEnabled();
+  ROS_INFO("[%s] Successfully prepared for actuation", this->name_.c_str());
 }
 
-void Joint::actuateRad(double targetPositionRad)
+void Joint::actuateRad(double target_position)
 {
-  if (!this->allowActuation)
+  if (!this->allow_actuation_)
   {
     throw error::HardwareException(error::ErrorType::NOT_ALLOWED_TO_ACTUATE, "Joint %s is not allowed to actuate",
-                                   this->name.c_str());
+                                   this->name_.c_str());
   }
-  this->iMotionCube->actuateRad(targetPositionRad);
+  this->imc_->actuateRad(target_position);
 }
 
 double Joint::getAngleRadAbsolute()
 {
-  if (!hasIMotionCube())
+  if (!this->hasIMotionCube())
   {
-    ROS_WARN("[%s] Has no iMotionCube", this->name.c_str());
+    ROS_WARN("[%s] Has no iMotionCube", this->name_.c_str());
     return -1;
   }
-  return this->iMotionCube->getAngleRadAbsolute();
+  return this->imc_->getAngleRadAbsolute();
 }
 
 double Joint::getAngleRadIncremental()
 {
-  if (!hasIMotionCube())
+  if (!this->hasIMotionCube())
   {
-    ROS_WARN("[%s] Has no iMotionCube", this->name.c_str());
+    ROS_WARN("[%s] Has no iMotionCube", this->name_.c_str());
     return -1;
   }
-  return this->iMotionCube->getAngleRadIncremental();
+  return this->imc_->getAngleRadIncremental();
 }
 
 double Joint::getAngleRadMostPrecise()
 {
-  if (!hasIMotionCube())
+  if (!this->hasIMotionCube())
   {
-    ROS_WARN("[%s] Has no iMotionCube", this->name.c_str());
+    ROS_WARN("[%s] Has no iMotionCube", this->name_.c_str());
     return -1;
   }
-  return this->iMotionCube->getAngleRadMostPrecise();
+  return this->imc_->getAngleRadMostPrecise();
 }
 
-void Joint::actuateTorque(int16_t targetTorque)
+void Joint::actuateTorque(int16_t target_torque)
 {
-  if (!this->allowActuation)
+  if (!this->allow_actuation_)
   {
     throw error::HardwareException(error::ErrorType::NOT_ALLOWED_TO_ACTUATE, "Joint %s is not allowed to actuate",
-                                   this->name.c_str());
+                                   this->name_.c_str());
   }
-  this->iMotionCube->actuateTorque(targetTorque);
+  this->imc_->actuateTorque(target_torque);
 }
 
 int16_t Joint::getTorque()
 {
-  if (!hasIMotionCube())
+  if (!this->hasIMotionCube())
   {
-    ROS_WARN("[%s] Has no iMotionCube", this->name.c_str());
+    ROS_WARN("[%s] Has no iMotionCube", this->name_.c_str());
     return -1;
   }
-  return this->iMotionCube->getTorque();
+  return this->imc_->getTorque();
 }
 
 int32_t Joint::getAngleIUAbsolute()
 {
-  if (!hasIMotionCube())
+  if (!this->hasIMotionCube())
   {
-    ROS_WARN("[%s] Has no iMotionCube", this->name.c_str());
+    ROS_WARN("[%s] Has no iMotionCube", this->name_.c_str());
     return -1;
   }
-  return this->iMotionCube->getAngleIUAbsolute();
+  return this->imc_->getAngleIUAbsolute();
 }
 
 int32_t Joint::getAngleIUIncremental()
 {
-  if (!hasIMotionCube())
+  if (!this->hasIMotionCube())
   {
-    ROS_WARN("[%s] Has no iMotionCube", this->name.c_str());
+    ROS_WARN("[%s] Has no iMotionCube", this->name_.c_str());
     return -1;
   }
-  return this->iMotionCube->getAngleIUIncremental();
+  return this->imc_->getAngleIUIncremental();
 }
 
 float Joint::getTemperature()
 {
-  if (!hasTemperatureGES())
+  if (!this->hasTemperatureGES())
   {
-    ROS_WARN("[%s] Has no temperature sensor", this->name.c_str());
+    ROS_WARN("[%s] Has no temperature sensor", this->name_.c_str());
     return -1;
   }
-  return this->temperatureGES.getTemperature();
+  return this->temperature_ges_->getTemperature();
 }
 
 IMotionCubeState Joint::getIMotionCubeState()
 {
   IMotionCubeState states;
 
-  std::bitset<16> statusWordBits = this->iMotionCube->getStatusWord();
+  std::bitset<16> statusWordBits = this->imc_->getStatusWord();
   states.statusWord = statusWordBits.to_string();
-  std::bitset<16> detailedErrorBits = this->iMotionCube->getDetailedError();
+  std::bitset<16> detailedErrorBits = this->imc_->getDetailedError();
   states.detailedError = detailedErrorBits.to_string();
-  std::bitset<16> motionErrorBits = this->iMotionCube->getMotionError();
+  std::bitset<16> motionErrorBits = this->imc_->getMotionError();
   states.motionError = motionErrorBits.to_string();
 
-  states.state = IMCState(this->iMotionCube->getStatusWord());
-  states.detailedErrorDescription = error::parseDetailedError(this->iMotionCube->getDetailedError());
-  states.motionErrorDescription = error::parseMotionError(this->iMotionCube->getMotionError());
+  states.state = IMCState(this->imc_->getStatusWord());
+  states.detailedErrorDescription = error::parseDetailedError(this->imc_->getDetailedError());
+  states.motionErrorDescription = error::parseMotionError(this->imc_->getMotionError());
 
-  states.motorCurrent = this->iMotionCube->getMotorCurrent();
-  states.motorVoltage = this->iMotionCube->getMotorVoltage();
+  states.motorCurrent = this->imc_->getMotorCurrent();
+  states.motorVoltage = this->imc_->getMotorVoltage();
 
-  states.absoluteEncoderValue = this->iMotionCube->getAngleIUAbsolute();
-  states.incrementalEncoderValue = this->iMotionCube->getAngleIUIncremental();
+  states.absoluteEncoderValue = this->imc_->getAngleIUAbsolute();
+  states.incrementalEncoderValue = this->imc_->getAngleIUIncremental();
 
   return states;
 }
 
-void Joint::setName(const std::string& name)
+void Joint::setAllowActuation(bool allow_actuation)
 {
-  Joint::name = name;
-}
-void Joint::setAllowActuation(bool allowActuation)
-{
-  Joint::allowActuation = allowActuation;
+  this->allow_actuation_ = allow_actuation;
 }
 
-void Joint::setTemperatureGes(const TemperatureGES& temperatureGes)
+int Joint::getTemperatureGESSlaveIndex() const
 {
-  temperatureGES = temperatureGes;
-}
-
-int Joint::getTemperatureGESSlaveIndex()
-{
-  if (hasTemperatureGES())
+  if (this->hasTemperatureGES())
   {
-    return this->temperatureGES.getSlaveIndex();
+    return this->temperature_ges_->getSlaveIndex();
   }
   return -1;
 }
 
-int Joint::getIMotionCubeSlaveIndex()
+int Joint::getIMotionCubeSlaveIndex() const
 {
-  if (hasIMotionCube())
+  if (this->hasIMotionCube())
   {
-    return this->iMotionCube->getSlaveIndex();
+    return this->imc_->getSlaveIndex();
   }
   return -1;
 }
-std::string Joint::getName()
+
+int Joint::getNetNumber() const
 {
-  return this->name;
+  return this->net_number_;
 }
 
-bool Joint::hasIMotionCube()
+std::string Joint::getName() const
 {
-  return this->iMotionCube->getSlaveIndex() != -1;
+  return this->name_;
 }
 
-bool Joint::hasTemperatureGES()
+bool Joint::hasIMotionCube() const
 {
-  return this->temperatureGES.getSlaveIndex() != -1;
+  return this->imc_ && this->imc_->getSlaveIndex() != -1;
 }
 
-bool Joint::canActuate()
+bool Joint::hasTemperatureGES() const
 {
-  return this->allowActuation;
+  return this->temperature_ges_ && this->temperature_ges_->getSlaveIndex() != -1;
 }
 
-void Joint::setNetNumber(int netNumber)
+bool Joint::canActuate() const
 {
-  Joint::netNumber = netNumber;
+  return this->allow_actuation_;
 }
 
 ActuationMode Joint::getActuationMode() const
 {
-  return this->iMotionCube->getActuationMode();
+  return this->imc_->getActuationMode();
 }
 
 }  // namespace march

--- a/march_hardware/src/MarchRobot.cpp
+++ b/march_hardware/src/MarchRobot.cpp
@@ -141,7 +141,7 @@ int MarchRobot::getEthercatCycleTime() const
   return this->ethercatMaster.getCycleTime();
 }
 
-Joint MarchRobot::getJoint(::std::string jointName)
+Joint& MarchRobot::getJoint(::std::string jointName)
 {
   if (!ethercatMaster.isOperational())
   {

--- a/march_hardware/test/TestIMotionCube.cpp
+++ b/march_hardware/test/TestIMotionCube.cpp
@@ -56,6 +56,7 @@ TEST_F(IMotionCubeTest, ActuationModePositionActuateTorque)
 
 TEST_F(IMotionCubeTest, OperationEnabledWithoutActuationMode)
 {
-  march::IMotionCube imc(1, std::move(this->mock_absolute_encoder), std::move(this->mock_incremental_encoder), march::ActuationMode::unknown);
+  march::IMotionCube imc(1, std::move(this->mock_absolute_encoder), std::move(this->mock_incremental_encoder),
+                         march::ActuationMode::unknown);
   ASSERT_THROW(imc.goToOperationEnabled(), march::error::HardwareException);
 }

--- a/march_hardware/test/TestIMotionCube.cpp
+++ b/march_hardware/test/TestIMotionCube.cpp
@@ -6,6 +6,7 @@
 #include <march_hardware/error/hardware_exception.h>
 
 #include <memory>
+#include <stdexcept>
 #include <utility>
 
 #include <gtest/gtest.h>
@@ -22,6 +23,18 @@ protected:
   std::unique_ptr<MockAbsoluteEncoder> mock_absolute_encoder;
   std::unique_ptr<MockIncrementalEncoder> mock_incremental_encoder;
 };
+
+TEST_F(IMotionCubeTest, NoAbsoluteEncoder)
+{
+  ASSERT_THROW(march::IMotionCube(1, nullptr, std::move(this->mock_incremental_encoder), march::ActuationMode::unknown),
+               std::invalid_argument);
+}
+
+TEST_F(IMotionCubeTest, NoIncrementalEncoder)
+{
+  ASSERT_THROW(march::IMotionCube(1, std::move(this->mock_absolute_encoder), nullptr, march::ActuationMode::unknown),
+               std::invalid_argument);
+}
 
 TEST_F(IMotionCubeTest, SlaveIndexOne)
 {

--- a/march_hardware/test/TestIMotionCube.cpp
+++ b/march_hardware/test/TestIMotionCube.cpp
@@ -3,8 +3,6 @@
 #include "mocks/MockIncrementalEncoder.cpp"
 
 #include <march_hardware/IMotionCube.h>
-#include <march_hardware/encoder/AbsoluteEncoder.h>
-#include <march_hardware/encoder/IncrementalEncoder.h>
 #include <march_hardware/error/hardware_exception.h>
 
 #include <memory>
@@ -58,6 +56,6 @@ TEST_F(IMotionCubeTest, ActuationModePositionActuateTorque)
 
 TEST_F(IMotionCubeTest, OperationEnabledWithoutActuationMode)
 {
-  march::IMotionCube imc(1, this->mock_absolute_encoder, this->mock_incremental_encoder, march::ActuationMode::unknown);
+  march::IMotionCube imc(1, std::move(this->mock_absolute_encoder), std::move(this->mock_incremental_encoder), march::ActuationMode::unknown);
   ASSERT_THROW(imc.goToOperationEnabled(), march::error::HardwareException);
 }

--- a/march_hardware/test/TestIMotionCube.cpp
+++ b/march_hardware/test/TestIMotionCube.cpp
@@ -2,33 +2,47 @@
 #include "mocks/MockAbsoluteEncoder.cpp"
 #include "mocks/MockIncrementalEncoder.cpp"
 
-#include <march_hardware/error/hardware_exception.h>
 #include <march_hardware/IMotionCube.h>
+#include <march_hardware/encoder/AbsoluteEncoder.h>
+#include <march_hardware/encoder/IncrementalEncoder.h>
+#include <march_hardware/error/hardware_exception.h>
+
+#include <memory>
+#include <utility>
 
 #include <gtest/gtest.h>
 
 class IMotionCubeTest : public ::testing::Test
 {
 protected:
-  MockAbsoluteEncoder mock_absolute_encoder;
-  MockIncrementalEncoder mock_incremental_encoder;
+  void SetUp() override
+  {
+    this->mock_absolute_encoder = std::make_unique<MockAbsoluteEncoder>();
+    this->mock_incremental_encoder = std::make_unique<MockIncrementalEncoder>();
+  }
+
+  std::unique_ptr<MockAbsoluteEncoder> mock_absolute_encoder;
+  std::unique_ptr<MockIncrementalEncoder> mock_incremental_encoder;
 };
 
 TEST_F(IMotionCubeTest, SlaveIndexOne)
 {
-  march::IMotionCube imc(1, this->mock_absolute_encoder, this->mock_incremental_encoder, march::ActuationMode::unknown);
+  march::IMotionCube imc(1, std::move(this->mock_absolute_encoder), std::move(this->mock_incremental_encoder),
+                         march::ActuationMode::unknown);
   ASSERT_EQ(1, imc.getSlaveIndex());
 }
 
 TEST_F(IMotionCubeTest, NoActuationMode)
 {
-  march::IMotionCube imc(1, this->mock_absolute_encoder, this->mock_incremental_encoder, march::ActuationMode::unknown);
+  march::IMotionCube imc(1, std::move(this->mock_absolute_encoder), std::move(this->mock_incremental_encoder),
+                         march::ActuationMode::unknown);
   ASSERT_THROW(imc.actuateRad(1), march::error::HardwareException);
 }
 
 TEST_F(IMotionCubeTest, ActuationModeTorqueActuateRad)
 {
-  march::IMotionCube imc(1, this->mock_absolute_encoder, this->mock_incremental_encoder, march::ActuationMode::torque);
+  march::IMotionCube imc(1, std::move(this->mock_absolute_encoder), std::move(this->mock_incremental_encoder),
+                         march::ActuationMode::torque);
 
   ASSERT_EQ(march::ActuationMode::torque, imc.getActuationMode().getValue());
   ASSERT_THROW(imc.actuateRad(1), march::error::HardwareException);
@@ -36,7 +50,7 @@ TEST_F(IMotionCubeTest, ActuationModeTorqueActuateRad)
 
 TEST_F(IMotionCubeTest, ActuationModePositionActuateTorque)
 {
-  march::IMotionCube imc(1, this->mock_absolute_encoder, this->mock_incremental_encoder,
+  march::IMotionCube imc(1, std::move(this->mock_absolute_encoder), std::move(this->mock_incremental_encoder),
                          march::ActuationMode::position);
 
   ASSERT_THROW(imc.actuateTorque(1), march::error::HardwareException);

--- a/march_hardware/test/TestJoint.cpp
+++ b/march_hardware/test/TestJoint.cpp
@@ -7,8 +7,6 @@
 
 #include "march_hardware/error/hardware_exception.h"
 #include "march_hardware/Joint.h"
-#include "march_hardware/TemperatureGES.h"
-#include "march_hardware/IMotionCube.h"
 #include "mocks/MockTemperatureGES.cpp"
 #include "mocks/MockIMotionCube.cpp"
 
@@ -20,45 +18,39 @@ protected:
     this->imc = std::make_unique<MockIMotionCube>();
   }
 
-  const float temperature = 42;
   std::unique_ptr<MockIMotionCube> imc;
 };
 
 TEST_F(JointTest, AllowActuation)
 {
-  march::Joint joint(std::move(this->imc));
+  march::Joint joint("test", 0);
   joint.setAllowActuation(true);
   ASSERT_TRUE(joint.canActuate());
 }
 
 TEST_F(JointTest, DisableActuation)
 {
-  march::Joint joint(std::move(this->imc));
+  march::Joint joint("test", 0);
   joint.setAllowActuation(false);
   ASSERT_FALSE(joint.canActuate());
 }
 
 TEST_F(JointTest, ActuatePositionDisableActuation)
 {
-  march::Joint joint(std::move(this->imc));
-  joint.setAllowActuation(false);
-  joint.setName("actuate_false");
+  march::Joint joint("actuate_false", 0, false, std::move(this->imc));
   EXPECT_FALSE(joint.canActuate());
   ASSERT_THROW(joint.actuateRad(0.3), march::error::HardwareException);
 }
 
 TEST_F(JointTest, ActuateTorqueDisableActuation)
 {
-  march::Joint joint(std::move(this->imc));
-  joint.setAllowActuation(false);
-  joint.setName("actuate_false");
+  march::Joint joint("actuate_false", 0, false, std::move(this->imc));
   EXPECT_FALSE(joint.canActuate());
   ASSERT_THROW(joint.actuateTorque(3), march::error::HardwareException);
 }
 
 TEST_F(JointTest, PrepareForActuationWithUnknownMode)
 {
-  march::Joint joint(std::move(this->imc));
-  joint.setAllowActuation(true);
+  march::Joint joint("actuate_false", 0, true, std::move(this->imc));
   ASSERT_THROW(joint.prepareActuation(), march::error::HardwareException);
 }

--- a/march_hardware/test/TestJoint.cpp
+++ b/march_hardware/test/TestJoint.cpp
@@ -1,37 +1,70 @@
 // Copyright 2018 Project March.
+#include "mocks/MockTemperatureGES.cpp"
+#include "mocks/MockIMotionCube.cpp"
+#include "march_hardware/error/hardware_exception.h"
+#include "march_hardware/Joint.h"
+
 #include <memory>
 #include <utility>
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
-#include "march_hardware/error/hardware_exception.h"
-#include "march_hardware/Joint.h"
-#include "mocks/MockTemperatureGES.cpp"
-#include "mocks/MockIMotionCube.cpp"
+using testing::Eq;
+using testing::Return;
 
-class JointTest : public ::testing::Test
+class JointTest : public testing::Test
 {
 protected:
   void SetUp() override
   {
     this->imc = std::make_unique<MockIMotionCube>();
+    this->temperature_ges = std::make_unique<MockTemperatureGES>();
   }
 
   std::unique_ptr<MockIMotionCube> imc;
+  std::unique_ptr<MockTemperatureGES> temperature_ges;
 };
+
+TEST_F(JointTest, InitializeWithoutMotorControllerAndGes)
+{
+  march::Joint joint("test", 0);
+  ASSERT_NO_THROW(joint.initialize(1));
+}
+
+TEST_F(JointTest, InitializeWithoutTemperatureGes)
+{
+  const int expected_cycle = 3;
+  EXPECT_CALL(*this->imc, writeInitialSDOs(Eq(expected_cycle))).Times(1);
+
+  march::Joint joint("test", 0, false, std::move(this->imc));
+  ASSERT_NO_THROW(joint.initialize(expected_cycle));
+}
+
+TEST_F(JointTest, InitializeWithoutMotorController)
+{
+  const int expected_cycle = 3;
+  EXPECT_CALL(*this->temperature_ges, writeInitialSDOs(Eq(expected_cycle))).Times(1);
+
+  march::Joint joint("test", 0, false, nullptr, std::move(this->temperature_ges));
+  ASSERT_NO_THROW(joint.initialize(expected_cycle));
+}
 
 TEST_F(JointTest, AllowActuation)
 {
-  march::Joint joint("test", 0);
-  joint.setAllowActuation(true);
+  march::Joint joint("test", 0, true, std::move(this->imc));
   ASSERT_TRUE(joint.canActuate());
+}
+
+TEST_F(JointTest, DisallowActuationWithoutMotorController)
+{
+  march::Joint joint("test", 0, true, nullptr);
+  ASSERT_FALSE(joint.canActuate());
 }
 
 TEST_F(JointTest, DisableActuation)
 {
-  march::Joint joint("test", 0);
-  joint.setAllowActuation(false);
+  march::Joint joint("test", 0, false, std::move(this->imc));
   ASSERT_FALSE(joint.canActuate());
 }
 
@@ -42,6 +75,15 @@ TEST_F(JointTest, ActuatePositionDisableActuation)
   ASSERT_THROW(joint.actuateRad(0.3), march::error::HardwareException);
 }
 
+TEST_F(JointTest, ActuatePosition)
+{
+  const double expected_rad = 5;
+  EXPECT_CALL(*this->imc, actuateRad(Eq(expected_rad))).Times(1);
+
+  march::Joint joint("actuate_false", 0, true, std::move(this->imc));
+  ASSERT_NO_THROW(joint.actuateRad(expected_rad));
+}
+
 TEST_F(JointTest, ActuateTorqueDisableActuation)
 {
   march::Joint joint("actuate_false", 0, false, std::move(this->imc));
@@ -49,8 +91,39 @@ TEST_F(JointTest, ActuateTorqueDisableActuation)
   ASSERT_THROW(joint.actuateTorque(3), march::error::HardwareException);
 }
 
-TEST_F(JointTest, PrepareForActuationWithUnknownMode)
+TEST_F(JointTest, ActuateTorque)
 {
+  const int16_t expected_torque = 5;
+  EXPECT_CALL(*this->imc, actuateTorque(Eq(expected_torque))).Times(1);
+
   march::Joint joint("actuate_false", 0, true, std::move(this->imc));
+  ASSERT_NO_THROW(joint.actuateTorque(expected_torque));
+}
+
+TEST_F(JointTest, PrepareForActuationNotAllowed)
+{
+  march::Joint joint("actuate_false", 0, false, std::move(this->imc));
   ASSERT_THROW(joint.prepareActuation(), march::error::HardwareException);
+}
+
+TEST_F(JointTest, PrepareForActuationAllowed)
+{
+  EXPECT_CALL(*this->imc, goToOperationEnabled()).Times(1);
+  march::Joint joint("actuate_true", 0, true, std::move(this->imc));
+  ASSERT_NO_THROW(joint.prepareActuation());
+}
+
+TEST_F(JointTest, GetTemperature)
+{
+  const float expected_temperature = 45.0;
+  EXPECT_CALL(*this->temperature_ges, getTemperature()).WillOnce(Return(expected_temperature));
+
+  march::Joint joint("get_temperature", 0, false, nullptr, std::move(this->temperature_ges));
+  ASSERT_FLOAT_EQ(joint.getTemperature(), expected_temperature);
+}
+
+TEST_F(JointTest, GetTemperatureWithoutTemperatureGes)
+{
+  march::Joint joint("get_temperature", 0, false, nullptr, nullptr);
+  ASSERT_FLOAT_EQ(joint.getTemperature(), -1.0);
 }

--- a/march_hardware/test/TestJoint.cpp
+++ b/march_hardware/test/TestJoint.cpp
@@ -1,6 +1,9 @@
 // Copyright 2018 Project March.
+#include <memory>
+#include <utility>
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include "march_hardware/error/hardware_exception.h"
 #include "march_hardware/Joint.h"
@@ -12,27 +15,32 @@
 class JointTest : public ::testing::Test
 {
 protected:
+  void SetUp() override
+  {
+    this->imc = std::make_unique<MockIMotionCube>();
+  }
+
   const float temperature = 42;
-  const MockIMotionCube imc;
+  std::unique_ptr<MockIMotionCube> imc;
 };
 
 TEST_F(JointTest, AllowActuation)
 {
-  march::Joint joint(this->imc);
+  march::Joint joint(std::move(this->imc));
   joint.setAllowActuation(true);
   ASSERT_TRUE(joint.canActuate());
 }
 
 TEST_F(JointTest, DisableActuation)
 {
-  march::Joint joint(this->imc);
+  march::Joint joint(std::move(this->imc));
   joint.setAllowActuation(false);
   ASSERT_FALSE(joint.canActuate());
 }
 
 TEST_F(JointTest, ActuatePositionDisableActuation)
 {
-  march::Joint joint(this->imc);
+  march::Joint joint(std::move(this->imc));
   joint.setAllowActuation(false);
   joint.setName("actuate_false");
   EXPECT_FALSE(joint.canActuate());
@@ -41,7 +49,7 @@ TEST_F(JointTest, ActuatePositionDisableActuation)
 
 TEST_F(JointTest, ActuateTorqueDisableActuation)
 {
-  march::Joint joint(this->imc);
+  march::Joint joint(std::move(this->imc));
   joint.setAllowActuation(false);
   joint.setName("actuate_false");
   EXPECT_FALSE(joint.canActuate());
@@ -50,7 +58,7 @@ TEST_F(JointTest, ActuateTorqueDisableActuation)
 
 TEST_F(JointTest, PrepareForActuationWithUnknownMode)
 {
-  march::Joint joint(this->imc);
+  march::Joint joint(std::move(this->imc));
   joint.setAllowActuation(true);
   ASSERT_THROW(joint.prepareActuation(), march::error::HardwareException);
 }

--- a/march_hardware/test/TestJoint.cpp
+++ b/march_hardware/test/TestJoint.cpp
@@ -68,6 +68,28 @@ TEST_F(JointTest, DisableActuation)
   ASSERT_FALSE(joint.canActuate());
 }
 
+TEST_F(JointTest, SetAllowActuation)
+{
+  march::Joint joint("test", 0, false, std::move(this->imc));
+  ASSERT_FALSE(joint.canActuate());
+  joint.setAllowActuation(true);
+  ASSERT_TRUE(joint.canActuate());
+}
+
+TEST_F(JointTest, GetName)
+{
+  const std::string expected_name = "test";
+  march::Joint joint(expected_name, 0, false, std::move(this->imc));
+  ASSERT_EQ(expected_name, joint.getName());
+}
+
+TEST_F(JointTest, GetNetNumber)
+{
+  const int expected_net_number = 2;
+  march::Joint joint("test", expected_net_number, false, std::move(this->imc));
+  ASSERT_EQ(expected_net_number, joint.getNetNumber());
+}
+
 TEST_F(JointTest, ActuatePositionDisableActuation)
 {
   march::Joint joint("actuate_false", 0, false, std::move(this->imc));

--- a/march_hardware/test/mocks/MockEncoder.cpp
+++ b/march_hardware/test/mocks/MockEncoder.cpp
@@ -5,7 +5,7 @@
 class MockEncoder : public march::Encoder
 {
 public:
-  MockEncoder(size_t number_of_bits) : Encoder(number_of_bits)
+  explicit MockEncoder(size_t number_of_bits) : Encoder(number_of_bits)
   {
   }
 

--- a/march_hardware/test/mocks/MockIMotionCube.cpp
+++ b/march_hardware/test/mocks/MockIMotionCube.cpp
@@ -15,5 +15,10 @@ public:
                   march::ActuationMode::unknown)
   {
   }
-  MOCK_METHOD0(getAngle, float());
+
+  MOCK_METHOD1(writeInitialSDOs, void(int));
+  MOCK_METHOD0(goToOperationEnabled, void());
+
+  MOCK_METHOD1(actuateRad, void(double));
+  MOCK_METHOD1(actuateTorque, void(int16_t));
 };

--- a/march_hardware/test/mocks/MockIMotionCube.cpp
+++ b/march_hardware/test/mocks/MockIMotionCube.cpp
@@ -3,12 +3,16 @@
 
 #include "march_hardware/IMotionCube.h"
 
+#include <memory>
+
 #include <gmock/gmock.h>
 
 class MockIMotionCube : public march::IMotionCube
 {
 public:
-  MockIMotionCube() : IMotionCube(1, MockAbsoluteEncoder(), MockIncrementalEncoder(), march::ActuationMode::unknown)
+  MockIMotionCube()
+    : IMotionCube(1, std::make_unique<MockAbsoluteEncoder>(), std::make_unique<MockIncrementalEncoder>(),
+                  march::ActuationMode::unknown)
   {
   }
   MOCK_METHOD0(getAngle, float());

--- a/march_hardware/test/mocks/MockTemperatureGES.cpp
+++ b/march_hardware/test/mocks/MockTemperatureGES.cpp
@@ -1,9 +1,15 @@
-#include "gmock/gmock.h"  // Brings in Google Mock.
 #include "march_hardware/TemperatureGES.h"
+
+#include <gmock/gmock.h>
 
 class MockTemperatureGES : public march::TemperatureGES
 {
 public:
+  MockTemperatureGES() : march::TemperatureGES(1, 0)
+  {
+  }
+
+  MOCK_METHOD1(writeInitialSDOs, void(int));
   MOCK_METHOD0(getTemperature, float());
   MOCK_METHOD0(getSlaveIndex, int());
 };

--- a/march_hardware_builder/include/march_hardware_builder/hardware_builder.h
+++ b/march_hardware_builder/include/march_hardware_builder/hardware_builder.h
@@ -66,12 +66,13 @@ public:
 
   static march::Joint createJoint(const YAML::Node& joint_config, const std::string& joint_name,
                                   const urdf::JointConstSharedPtr& urdf_joint);
-  static march::AbsoluteEncoder createAbsoluteEncoder(const YAML::Node& absolute_encoder_config,
-                                                      const urdf::JointConstSharedPtr& urdf_joint);
-  static march::IncrementalEncoder createIncrementalEncoder(const YAML::Node& incremental_encoder_config);
-  static march::IMotionCube createIMotionCube(const YAML::Node& imc_config, march::ActuationMode mode,
-                                              const urdf::JointConstSharedPtr& urdf_joint);
-  static march::TemperatureGES createTemperatureGES(const YAML::Node& temperature_ges_config);
+  static std::unique_ptr<march::AbsoluteEncoder> createAbsoluteEncoder(const YAML::Node& absolute_encoder_config,
+                                                                       const urdf::JointConstSharedPtr& urdf_joint);
+  static std::unique_ptr<march::IncrementalEncoder>
+  createIncrementalEncoder(const YAML::Node& incremental_encoder_config);
+  static std::unique_ptr<march::IMotionCube> createIMotionCube(const YAML::Node& imc_config, march::ActuationMode mode,
+                                                               const urdf::JointConstSharedPtr& urdf_joint);
+  static std::unique_ptr<march::TemperatureGES> createTemperatureGES(const YAML::Node& temperature_ges_config);
   static march::PowerDistributionBoard createPowerDistributionBoard(const YAML::Node& power_distribution_board_config);
 
   static const std::vector<std::string> INCREMENTAL_ENCODER_REQUIRED_KEYS;

--- a/march_hardware_builder/src/hardware_builder.cpp
+++ b/march_hardware_builder/src/hardware_builder.cpp
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <ros/ros.h>
@@ -48,13 +49,13 @@ std::unique_ptr<march::MarchRobot> HardwareBuilder::createMarchRobot()
 {
   this->initUrdf();
 
-  std::string robot_name = this->robot_config_.begin()->first.as<std::string>();
+  const auto robot_name = this->robot_config_.begin()->first.as<std::string>();
   ROS_DEBUG_STREAM("Starting creation of robot " << robot_name);
 
   // Remove top level robot name key
   YAML::Node config = this->robot_config_[robot_name];
-  std::string if_name = config["ifName"].as<std::string>();
-  int cycle_time = config["ecatCycleTime"].as<int>();
+  const auto if_name = config["ifName"].as<std::string>();
+  const auto cycle_time = config["ecatCycleTime"].as<int>();
 
   YAML::Node joint_list_config = config["joints"];
 
@@ -62,22 +63,23 @@ std::unique_ptr<march::MarchRobot> HardwareBuilder::createMarchRobot()
 
   for (const YAML::Node& joint_config : joint_list_config)
   {
-    std::string joint_name = joint_config.begin()->first.as<std::string>();
-    joint_list.push_back(
+    const auto joint_name = joint_config.begin()->first.as<std::string>();
+    march::Joint joint(
         HardwareBuilder::createJoint(joint_config[joint_name], joint_name, this->urdf_.getJoint(joint_name)));
+    joint_list.push_back(std::move(joint));
   }
 
   ROS_INFO_STREAM("Robot config:\n" << config);
   YAML::Node pdb_config = config["powerDistributionBoard"];
   if (pdb_config)
   {
-    march::PowerDistributionBoard pdb = HardwareBuilder::createPowerDistributionBoard(pdb_config);
-    return std::make_unique<march::MarchRobot>(joint_list, this->urdf_, pdb, if_name, cycle_time);
+    auto pdb = HardwareBuilder::createPowerDistributionBoard(pdb_config);
+    return std::make_unique<march::MarchRobot>(std::move(joint_list), this->urdf_, pdb, if_name, cycle_time);
   }
   else
   {
     ROS_INFO("powerDistributionBoard is NOT defined");
-    return std::make_unique<march::MarchRobot>(joint_list, this->urdf_, if_name, cycle_time);
+    return std::make_unique<march::MarchRobot>(std::move(joint_list), this->urdf_, if_name, cycle_time);
   }
 }
 
@@ -87,63 +89,71 @@ march::Joint HardwareBuilder::createJoint(const YAML::Node& joint_config, const 
   ROS_DEBUG("Starting creation of joint %s", joint_name.c_str());
   HardwareBuilder::validateRequiredKeysExist(joint_config, HardwareBuilder::JOINT_REQUIRED_KEYS, "joint");
 
+  auto net_number = -1;
+  if (joint_config["netNumber"])
+  {
+    net_number = joint_config["netNumber"].as<int>();
+  }
+  else
+  {
+    ROS_WARN("Joint %s does not have a netNumber", joint_name.c_str());
+  }
+
+  const auto allow_actuation = joint_config["allowActuation"].as<bool>();
+
   march::ActuationMode mode;
   if (joint_config["actuationMode"])
   {
     mode = march::ActuationMode(joint_config["actuationMode"].as<std::string>());
   }
 
-  march::IMotionCube imc = HardwareBuilder::createIMotionCube(joint_config["imotioncube"], mode, urdf_joint);
-
-  march::Joint joint(imc);
-  joint.setName(joint_name);
-
-  bool allowActuation = joint_config["allowActuation"].as<bool>();
-  joint.setAllowActuation(allowActuation);
-
-  if (joint_config["netNumber"])
+  auto imc = HardwareBuilder::createIMotionCube(joint_config["imotioncube"], mode, urdf_joint);
+  if (!imc)
   {
-    joint.setNetNumber(joint_config["netNumber"].as<int>());
-  }
-  else
-  {
-    ROS_WARN("Joint %s does not have a netNumber", joint_name.c_str());
-    joint.setNetNumber(-1);
+    ROS_WARN("Joint %s does not have a configuration for an IMotionCube", joint_name.c_str());
   }
 
-  if (joint_config["temperatureges"])
-  {
-    march::TemperatureGES ges = HardwareBuilder::createTemperatureGES(joint_config["temperatureges"]);
-    joint.setTemperatureGes(ges);
-  }
-  else
+  auto ges = HardwareBuilder::createTemperatureGES(joint_config["temperatureges"]);
+  if (!ges)
   {
     ROS_WARN("Joint %s does not have a configuration for a TemperatureGes", joint_name.c_str());
   }
-  return joint;
+  return { joint_name, net_number, allow_actuation, std::move(imc), std::move(ges) };
 }
 
-march::IMotionCube HardwareBuilder::createIMotionCube(const YAML::Node& imc_config, march::ActuationMode mode,
-                                                      const urdf::JointConstSharedPtr& urdf_joint)
+std::unique_ptr<march::IMotionCube> HardwareBuilder::createIMotionCube(const YAML::Node& imc_config,
+                                                                       march::ActuationMode mode,
+                                                                       const urdf::JointConstSharedPtr& urdf_joint)
 {
+  if (!imc_config)
+  {
+    return nullptr;
+  }
+
   HardwareBuilder::validateRequiredKeysExist(imc_config, HardwareBuilder::IMOTIONCUBE_REQUIRED_KEYS, "imotioncube");
 
   YAML::Node incremental_encoder_config = imc_config["incrementalEncoder"];
   YAML::Node absolute_encoder_config = imc_config["absoluteEncoder"];
   int slave_index = imc_config["slaveIndex"].as<int>();
-  return { slave_index, HardwareBuilder::createAbsoluteEncoder(absolute_encoder_config, urdf_joint),
-           HardwareBuilder::createIncrementalEncoder(incremental_encoder_config), mode };
+  return std::make_unique<march::IMotionCube>(
+      slave_index, HardwareBuilder::createAbsoluteEncoder(absolute_encoder_config, urdf_joint),
+      HardwareBuilder::createIncrementalEncoder(incremental_encoder_config), mode);
 }
 
-march::AbsoluteEncoder HardwareBuilder::createAbsoluteEncoder(const YAML::Node& absolute_encoder_config,
-                                                              const urdf::JointConstSharedPtr& urdf_joint)
+std::unique_ptr<march::AbsoluteEncoder> HardwareBuilder::createAbsoluteEncoder(
+    const YAML::Node& absolute_encoder_config, const urdf::JointConstSharedPtr& urdf_joint)
 {
+  if (!absolute_encoder_config)
+  {
+    return nullptr;
+  }
+
   HardwareBuilder::validateRequiredKeysExist(absolute_encoder_config, HardwareBuilder::ABSOLUTE_ENCODER_REQUIRED_KEYS,
                                              "absoluteEncoder");
 
-  auto resolution = absolute_encoder_config["resolution"].as<size_t>();
-  auto min_position = absolute_encoder_config["minPositionIU"].as<int32_t>();
-  auto max_position = absolute_encoder_config["maxPositionIU"].as<int32_t>();
+  const auto resolution = absolute_encoder_config["resolution"].as<size_t>();
+  const auto min_position = absolute_encoder_config["minPositionIU"].as<int32_t>();
+  const auto max_position = absolute_encoder_config["maxPositionIU"].as<int32_t>();
 
   double soft_lower_limit;
   double soft_upper_limit;
@@ -159,28 +169,39 @@ march::AbsoluteEncoder HardwareBuilder::createAbsoluteEncoder(const YAML::Node& 
     soft_upper_limit = urdf_joint->limits->upper;
   }
 
-  return { resolution,       min_position,    max_position, urdf_joint->limits->lower, urdf_joint->limits->upper,
-           soft_lower_limit, soft_upper_limit };
+  return std::make_unique<march::AbsoluteEncoder>(resolution, min_position, max_position, urdf_joint->limits->lower,
+                                                  urdf_joint->limits->upper, soft_lower_limit, soft_upper_limit);
 }
 
-march::IncrementalEncoder HardwareBuilder::createIncrementalEncoder(const YAML::Node& incremental_encoder_config)
+std::unique_ptr<march::IncrementalEncoder>
+HardwareBuilder::createIncrementalEncoder(const YAML::Node& incremental_encoder_config)
 {
+  if (!incremental_encoder_config)
+  {
+    return nullptr;
+  }
+
   HardwareBuilder::validateRequiredKeysExist(incremental_encoder_config,
                                              HardwareBuilder::INCREMENTAL_ENCODER_REQUIRED_KEYS, "incrementalEncoder");
 
-  auto resolution = incremental_encoder_config["resolution"].as<size_t>();
-  auto transmission = incremental_encoder_config["transmission"].as<double>();
-  return { resolution, transmission };
+  const auto resolution = incremental_encoder_config["resolution"].as<size_t>();
+  const auto transmission = incremental_encoder_config["transmission"].as<double>();
+  return std::make_unique<march::IncrementalEncoder>(resolution, transmission);
 }
 
-march::TemperatureGES HardwareBuilder::createTemperatureGES(const YAML::Node& temperature_ges_config)
+std::unique_ptr<march::TemperatureGES> HardwareBuilder::createTemperatureGES(const YAML::Node& temperature_ges_config)
 {
+  if (!temperature_ges_config)
+  {
+    return nullptr;
+  }
+
   HardwareBuilder::validateRequiredKeysExist(temperature_ges_config, HardwareBuilder::TEMPERATUREGES_REQUIRED_KEYS,
                                              "temperatureges");
 
-  int slave_index = temperature_ges_config["slaveIndex"].as<int>();
-  int byte_offset = temperature_ges_config["byteOffset"].as<int>();
-  return { slave_index, byte_offset };
+  const auto slave_index = temperature_ges_config["slaveIndex"].as<int>();
+  const auto byte_offset = temperature_ges_config["byteOffset"].as<int>();
+  return std::make_unique<march::TemperatureGES>(slave_index, byte_offset);
 }
 
 march::PowerDistributionBoard HardwareBuilder::createPowerDistributionBoard(const YAML::Node& pdb)
@@ -188,7 +209,7 @@ march::PowerDistributionBoard HardwareBuilder::createPowerDistributionBoard(cons
   HardwareBuilder::validateRequiredKeysExist(pdb, HardwareBuilder::POWER_DISTRIBUTION_BOARD_REQUIRED_KEYS,
                                              "powerdistributionboard");
 
-  int slave_index = pdb["slaveIndex"].as<int>();
+  const auto slave_index = pdb["slaveIndex"].as<int>();
   YAML::Node net_monitor_byte_offsets = pdb["netMonitorByteOffsets"];
   YAML::Node net_driver_byte_offsets = pdb["netDriverByteOffsets"];
   YAML::Node boot_shutdown_byte_offsets = pdb["bootShutdownOffsets"];

--- a/march_hardware_builder/test/absolute_encoder_builder_test.cpp
+++ b/march_hardware_builder/test/absolute_encoder_builder_test.cpp
@@ -41,8 +41,14 @@ TEST_F(TestAbsoluteEncoderBuilder, ValidEncoderHip)
   march::AbsoluteEncoder expected =
       march::AbsoluteEncoder(16, 22134, 43436, this->joint->limits->lower, this->joint->limits->upper,
                              this->joint->safety->soft_lower_limit, this->joint->safety->soft_upper_limit);
-  march::AbsoluteEncoder created = HardwareBuilder::createAbsoluteEncoder(config, this->joint);
-  ASSERT_EQ(expected, created);
+  auto created = HardwareBuilder::createAbsoluteEncoder(config, this->joint);
+  ASSERT_EQ(expected, *created);
+}
+
+TEST_F(TestAbsoluteEncoderBuilder, NoConfig)
+{
+  YAML::Node config;
+  ASSERT_EQ(nullptr, HardwareBuilder::createAbsoluteEncoder(config[""], this->joint));
 }
 
 TEST_F(TestAbsoluteEncoderBuilder, NoResolution)

--- a/march_hardware_builder/test/imc_builder_test.cpp
+++ b/march_hardware_builder/test/imc_builder_test.cpp
@@ -40,16 +40,23 @@ TEST_F(IMotionCubeTest, ValidIMotionCubeHip)
   this->joint->safety->soft_lower_limit = 0.1;
   this->joint->safety->soft_upper_limit = 1.9;
 
-  march::IMotionCube created = HardwareBuilder::createIMotionCube(config, march::ActuationMode::unknown, this->joint);
+  auto created = HardwareBuilder::createIMotionCube(config, march::ActuationMode::unknown, this->joint);
 
-  march::AbsoluteEncoder absolute_encoder =
-      march::AbsoluteEncoder(16, 22134, 43436, this->joint->limits->lower, this->joint->limits->upper,
-                             this->joint->safety->soft_lower_limit, this->joint->safety->soft_upper_limit);
-  march::IncrementalEncoder incremental_encoder = march::IncrementalEncoder(12, 101.0);
-  march::IMotionCube expected =
-      march::IMotionCube(2, absolute_encoder, incremental_encoder, march::ActuationMode::unknown);
+  auto absolute_encoder = std::make_unique<march::AbsoluteEncoder>(
+      16, 22134, 43436, this->joint->limits->lower, this->joint->limits->upper, this->joint->safety->soft_lower_limit,
+      this->joint->safety->soft_upper_limit);
+  auto incremental_encoder = std::make_unique<march::IncrementalEncoder>(12, 101.0);
+  march::IMotionCube expected(2, std::move(absolute_encoder), std::move(incremental_encoder),
+                              march::ActuationMode::unknown);
 
-  ASSERT_EQ(expected, created);
+  ASSERT_EQ(expected, *created);
+}
+
+TEST_F(IMotionCubeTest, NoConfig)
+{
+  YAML::Node config;
+  ASSERT_EQ(nullptr,
+            HardwareBuilder::createIMotionCube(config["imotioncube"], march::ActuationMode::unknown, this->joint));
 }
 
 TEST_F(IMotionCubeTest, NoAbsoluteEncoder)

--- a/march_hardware_builder/test/incremental_encoder_builder_test.cpp
+++ b/march_hardware_builder/test/incremental_encoder_builder_test.cpp
@@ -30,8 +30,14 @@ TEST_F(TestIncrementalEncoderBuilder, ValidIncrementalEncoder)
   YAML::Node config = this->loadTestYaml("/incremental_encoder_correct.yaml");
 
   march::IncrementalEncoder expected = march::IncrementalEncoder(12, 45.5);
-  march::IncrementalEncoder created = HardwareBuilder::createIncrementalEncoder(config);
-  ASSERT_EQ(expected, created);
+  auto created = HardwareBuilder::createIncrementalEncoder(config);
+  ASSERT_EQ(expected, *created);
+}
+
+TEST_F(TestIncrementalEncoderBuilder, NoConfig)
+{
+  YAML::Node config;
+  ASSERT_EQ(nullptr, HardwareBuilder::createIncrementalEncoder(config[""]));
 }
 
 TEST_F(TestIncrementalEncoderBuilder, NoResolution)

--- a/march_hardware_builder/test/joint_builder_test.cpp
+++ b/march_hardware_builder/test/joint_builder_test.cpp
@@ -40,20 +40,18 @@ TEST_F(JointTest, ValidJointHip)
   this->joint->safety->soft_lower_limit = 0.1;
   this->joint->safety->soft_upper_limit = 1.9;
 
-  march::Joint created = HardwareBuilder::createJoint(config, "test_joint_hip", this->joint);
+  const std::string name = "test_joint_hip";
+  march::Joint created = HardwareBuilder::createJoint(config, name, this->joint);
 
-  march::AbsoluteEncoder absolute_encoder =
-      march::AbsoluteEncoder(16, 22134, 43436, this->joint->limits->lower, this->joint->limits->upper,
-                             this->joint->safety->soft_lower_limit, this->joint->safety->soft_upper_limit);
-  march::IncrementalEncoder incremental_encoder = march::IncrementalEncoder(12, 50.0);
-  march::IMotionCube imc = march::IMotionCube(2, absolute_encoder, incremental_encoder, march::ActuationMode::unknown);
-  march::TemperatureGES ges = march::TemperatureGES(1, 2);
-  march::Joint expected(imc);
-  expected.setName("test_joint_hip");
-  expected.setAllowActuation(true);
-  expected.setTemperatureGes(ges);
+  auto absolute_encoder = std::make_unique<march::AbsoluteEncoder>(
+      16, 22134, 43436, this->joint->limits->lower, this->joint->limits->upper, this->joint->safety->soft_lower_limit,
+      this->joint->safety->soft_upper_limit);
+  auto incremental_encoder = std::make_unique<march::IncrementalEncoder>(12, 50.0);
+  auto imc = std::make_unique<march::IMotionCube>(2, std::move(absolute_encoder), std::move(incremental_encoder),
+                                                  march::ActuationMode::unknown);
+  auto ges = std::make_unique<march::TemperatureGES>(1, 2);
+  march::Joint expected(name, -1, true, std::move(imc), std::move(ges));
 
-  ASSERT_EQ("test_joint_hip", expected.getName());
   ASSERT_EQ(expected, created);
 }
 
@@ -67,19 +65,15 @@ TEST_F(JointTest, ValidNotActuated)
 
   march::Joint created = HardwareBuilder::createJoint(config, "test_joint_hip", this->joint);
 
-  march::AbsoluteEncoder absolute_encoder =
-      march::AbsoluteEncoder(16, 22134, 43436, this->joint->limits->lower, this->joint->limits->upper,
-                             this->joint->safety->soft_lower_limit, this->joint->safety->soft_upper_limit);
-  march::IncrementalEncoder incremental_encoder = march::IncrementalEncoder(12, 50.0);
-  march::IMotionCube imc = march::IMotionCube(2, absolute_encoder, incremental_encoder, march::ActuationMode::unknown);
-  march::TemperatureGES ges = march::TemperatureGES(1, 2);
-  march::Joint expected(imc);
-  expected.setName("test_joint_hip");
-  expected.setAllowActuation(false);
-  expected.setTemperatureGes(ges);
+  auto absolute_encoder = std::make_unique<march::AbsoluteEncoder>(
+      16, 22134, 43436, this->joint->limits->lower, this->joint->limits->upper, this->joint->safety->soft_lower_limit,
+      this->joint->safety->soft_upper_limit);
+  auto incremental_encoder = std::make_unique<march::IncrementalEncoder>(12, 50.0);
+  auto imc = std::make_unique<march::IMotionCube>(2, std::move(absolute_encoder), std::move(incremental_encoder),
+                                                  march::ActuationMode::unknown);
+  auto ges = std::make_unique<march::TemperatureGES>(1, 2);
+  march::Joint expected("test_joint_hip", -1, false, std::move(imc), std::move(ges));
 
-  ASSERT_EQ("test_joint_hip", expected.getName());
-  ASSERT_FALSE(expected.canActuate());
   ASSERT_EQ(expected, created);
 }
 
@@ -118,14 +112,14 @@ TEST_F(JointTest, ValidActuationMode)
 
   march::Joint created = HardwareBuilder::createJoint(config, "test_joint_hip", this->joint);
 
-  march::Joint expected(march::IMotionCube(
-      1,
-      march::AbsoluteEncoder(16, 22134, 43436, this->joint->limits->lower, this->joint->limits->upper,
-                             this->joint->safety->soft_lower_limit, this->joint->safety->soft_upper_limit),
-      march::IncrementalEncoder(12, 50.0), march::ActuationMode::position));
-  expected.setName("test_joint_hip");
+  march::Joint expected("test_joint_hip", -1, false,
+                        std::make_unique<march::IMotionCube>(
+                            1,
+                            std::make_unique<march::AbsoluteEncoder>(
+                                16, 22134, 43436, this->joint->limits->lower, this->joint->limits->upper,
+                                this->joint->safety->soft_lower_limit, this->joint->safety->soft_upper_limit),
+                            std::make_unique<march::IncrementalEncoder>(12, 50.0), march::ActuationMode::position));
 
-  ASSERT_EQ("test_joint_hip", expected.getName());
   ASSERT_EQ(expected, created);
 }
 

--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -106,7 +106,7 @@ bool MarchHardwareInterface::init(ros::NodeHandle& nh, ros::NodeHandle& /* robot
   // Initialize interfaces for each joint
   for (size_t i = 0; i < num_joints_; ++i)
   {
-    march::Joint joint = march_robot_->getJoint(joint_names_[i]);
+    march::Joint& joint = march_robot_->getJoint(joint_names_[i]);
     // Create joint state interface
     JointStateHandle joint_state_handle(joint.getName(), &joint_position_[i], &joint_velocity_[i], &joint_effort_[i]);
     joint_state_interface_.registerHandle(joint_state_handle);
@@ -198,7 +198,7 @@ void MarchHardwareInterface::read(const ros::Time& /* time */, const ros::Durati
   {
     const double old_relative_position = relative_joint_position_[i];
 
-    march::Joint joint = march_robot_->getJoint(joint_names_[i]);
+    march::Joint& joint = march_robot_->getJoint(joint_names_[i]);
 
     joint_position_[i] = joint.getAngleRadAbsolute();
     relative_joint_position_[i] = joint.getAngleRadMostPrecise();
@@ -242,7 +242,7 @@ void MarchHardwareInterface::write(const ros::Time& /* time */, const ros::Durat
 
   for (size_t i = 0; i < num_joints_; i++)
   {
-    march::Joint joint = march_robot_->getJoint(joint_names_[i]);
+    march::Joint& joint = march_robot_->getJoint(joint_names_[i]);
 
     if (joint.canActuate())
     {
@@ -381,7 +381,7 @@ void MarchHardwareInterface::updateAfterLimitJointCommand()
   after_limit_joint_command_pub_->msg_.header.stamp = ros::Time::now();
   for (size_t i = 0; i < num_joints_; i++)
   {
-    march::Joint joint = march_robot_->getJoint(joint_names_[i]);
+    march::Joint& joint = march_robot_->getJoint(joint_names_[i]);
 
     after_limit_joint_command_pub_->msg_.name[i] = joint.getName();
     after_limit_joint_command_pub_->msg_.position_command[i] = joint_position_command_[i];
@@ -439,7 +439,7 @@ void MarchHardwareInterface::iMotionCubeStateCheck(size_t joint_index)
 
 void MarchHardwareInterface::outsideLimitsCheck(size_t joint_index)
 {
-  march::Joint joint = march_robot_->getJoint(joint_names_[joint_index]);
+  march::Joint& joint = march_robot_->getJoint(joint_names_[joint_index]);
   if (joint_position_[joint_index] < soft_limits_[joint_index].min_position ||
       joint_position_[joint_index] > soft_limits_[joint_index].max_position)
   {


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

Closes PM-341

## Description
The mocks were used in the wrong way. They were being passed by value to their base classes which resulted in the mocked functions to be scraped away. So, for example, a function takes `Encoder` as type but you pass a `MockEncoder` which inherits from `Encoder`. The method only has space on its stack for an `Encoder` and since `MockEncoder` implements some overridden methods it does not fit in the memory space of `Encoder`. Therefore, the mocks were not used. Luckily this can be fixed by passing pointers. I implemented this using smart pointers, e.g. `std::unique_ptr`. This type of pointer destroys itself and ensures there is only one instance. This way you don't have to think about `delete`'ing pointers and worry about ownership.

Since pointers can also be `nullptr`, you have to check everywhere if a pointer is valid before using it. In `IMotionCube` class I solved this using a check on the encoders in the constructor, since these are required. In Joint I changed the check to allow for actuation to also check for an existing motor controller.

Finally, all further additions are tests using the mocks correctly (to increase the coverage).

## Changes
* Make `AbsoluteEncoder` and `IncrementalEncoder` injectable into `IMotionCube`
* Make `IMotionCube` and `TemperatureGes` injectable into `Joint`
* Write additional tests for `IMotionCube` and `Joint`
* Make `getJoint` in `MarchRobot` return a reference instead of a value to avoid copying.
* Refactor `Joint` a bit to make it less mutable and add constness (fixes PM-324)
* Make destructors `virtual` to enable for correctly destructing of inherited classes, e.g. mocks

<!-- Please don't forget to request for reviews -->
