### PR TITLE
Feature: increase ethercat thread priority

### DIFF
--- a/march_hardware/CMakeLists.txt
+++ b/march_hardware/CMakeLists.txt
@@ -63,7 +63,7 @@ add_library(${PROJECT_NAME}
     src/error/motion_error.cpp
 )
 
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} pthread)
 
 add_executable(slave_count_check check/slave_count.cpp)
 target_link_libraries(slave_count_check ${PROJECT_NAME})

--- a/march_hardware/include/march_hardware/EtherCAT/EthercatMaster.h
+++ b/march_hardware/include/march_hardware/EtherCAT/EthercatMaster.h
@@ -51,6 +51,8 @@ public:
    */
   void stop();
 
+  static const int THREAD_PRIORITY = 40;
+
 private:
   /**
    * Opens the ethernet port with the given ifname and checks the amount of slaves.
@@ -77,6 +79,15 @@ private:
    * Checks if all the slaves are connected and in operational state.
    */
   static void monitorSlaveConnection();
+
+  /**
+   * Sets the ethercat thread priority and scheduling
+   * to SCHED_FIFO using pthread.
+   * Note: Only works on POSIX compliant systems.
+   *
+   * @param priority a pthread priority value between 1 and 99 for SCHED_FIFO threads.
+   */
+  void setThreadPriority(int priority);
 
   std::atomic<bool> is_operational_;
 

--- a/march_hardware/src/EtherCAT/EthercatMaster.cpp
+++ b/march_hardware/src/EtherCAT/EthercatMaster.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include <pthread.h>
 #include <ros/ros.h>
 
 #include <soem/ethercattype.h>
@@ -119,9 +120,7 @@ void EthercatMaster::ethercatSlaveInitiation(std::vector<Joint>& joints)
     ROS_INFO("Operational state reached for all slaves");
     this->is_operational_ = true;
     this->ethercat_thread_ = std::thread(&EthercatMaster::ethercatLoop, this);
-    struct sched_param param;
-    param.sched_priority = 40;
-    pthread_setschedparam(this->ethercat_thread_.native_handle(), SCHED_FIFO, &param);
+    this->setThreadPriority(EthercatMaster::THREAD_PRIORITY);
   }
   else
   {
@@ -220,4 +219,19 @@ void EthercatMaster::stop()
   }
 }
 
+void EthercatMaster::setThreadPriority(int priority)
+{
+  struct sched_param param = { priority };
+  // SCHED_FIFO scheduling preempts other threads with lower priority as soon as it becomes runnable.
+  // See http://man7.org/linux/man-pages/man7/sched.7.html for more info.
+  const int error = pthread_setschedparam(this->ethercat_thread_.native_handle(), SCHED_FIFO, &param);
+  if (error != 0)
+  {
+    ROS_ERROR("Failed to set the ethercat thread priority to %d. (error code: %d)", priority, error);
+  }
+  else
+  {
+    ROS_DEBUG("Set ethercat thread priority to %d", param.sched_priority);
+  }
+}
 }  // namespace march

--- a/march_hardware/src/EtherCAT/EthercatMaster.cpp
+++ b/march_hardware/src/EtherCAT/EthercatMaster.cpp
@@ -119,6 +119,9 @@ void EthercatMaster::ethercatSlaveInitiation(std::vector<Joint>& joints)
     ROS_INFO("Operational state reached for all slaves");
     this->is_operational_ = true;
     this->ethercat_thread_ = std::thread(&EthercatMaster::ethercatLoop, this);
+    struct sched_param param;
+    param.sched_priority = 40;
+    pthread_setschedparam(this->ethercat_thread_.native_handle(), SCHED_FIFO, &param);
   }
   else
   {


### PR DESCRIPTION
Closes PM-311

## Description
In this PR I have researched the ethercat thread cycle time, to see if the ethercat thread should be given a higher priority or different scheduling priority.

In order to measure this I created a seperate branch,  [`time-ethercat-cycle`](https://github.com/project-march/hardware-interface/tree/time-ethercat-cycle), which measured ethercat thread timing. It measured the time it took to send and receive PDOs and it measured how long the ethercat cycle took in its entirety (including sleeping), which should always be 4ms. From this data I created histograms:

![cycles](https://user-images.githubusercontent.com/23523462/77540375-4257db00-6ea3-11ea-9ec9-ca7d6321230e.png)
![total](https://user-images.githubusercontent.com/23523462/77540390-4ab01600-6ea3-11ea-8b16-773f02d92732.png)

The first plot shows the sending and receiving of pdos and the second total duration. The y-axis are logarithmic. As you can see in the total duration there are a lot of cycles that take longer than 5ms.

Then I gave the ethercat thread more priority and gave it a different scheduling policy: `SCHED_FIFO`. This scheduling policy preempts other threads with lower priority as soon as it becomes runnable, i.e. wakes up from sleep. The priority has been set to 40 to give it more priority than other ROS nodes and not too high to avoid blocking OS stuff. Then I did the measurement again and got these results:

![cycles_with_prio](https://user-images.githubusercontent.com/23523462/77542247-2d307b80-6ea6-11ea-9d78-9add72457bdf.png)
![total_with_prio](https://user-images.githubusercontent.com/23523462/77542250-302b6c00-6ea6-11ea-8854-c7f16a58c751.png)

The ethercat sending and receiving PDOs now stays well under 2ms and the total duration is concentrated at 4ms, with many fewer outliers. As this improved the cycle times significantly, I propose to make this the default.

## Changes
* Add `setThreadPriority` method to set the ethercat thread priority
