### PR TITLE
Feature/pm 436 add subindex to pdo mapping

### DIFF
--- a/march_hardware/include/march_hardware/PDOmap.h
+++ b/march_hardware/include/march_hardware/PDOmap.h
@@ -15,14 +15,17 @@ namespace march
 /** Store IMC data as a struct to prevent data overlap.*/
 struct IMCObject
 {
-  uint16_t address;           // in IMC memory (see IMC manual)
-  uint16_t length;            // bits (see IMC manual)
+  uint16_t address;            // in IMC memory (see IMC manual)
+  uint8_t sub_index;          // sub index corresponding to PDO register (see IMC manual)
+  uint8_t length;             // bits (see IMC manual)
   uint32_t combined_address;  // combine the address(hex), sub-index(hex) and length(hex)
 
-  explicit IMCObject(uint16_t _address, uint16_t _length) : address(_address), length(_length)
+  explicit IMCObject(uint16_t _address, uint8_t _sub_index, uint8_t _length)
+    : address(_address), sub_index(_sub_index), length(_length)
   {
-    uint32_t MSword = ((address & 0xFFFF) << 16);  // Shift 16 bits left for most significant word
-    uint32_t LSword = (length & 0xFFFF);
+
+    uint32_t MSword = ((address & 0xFFFF) << 16);
+    uint32_t LSword = ((sub_index & 0xFFFF) << 8) | (length & 0xFFFF);
 
     combined_address = (MSword | LSword);
   }

--- a/march_hardware/include/march_hardware/PDOmap.h
+++ b/march_hardware/include/march_hardware/PDOmap.h
@@ -15,7 +15,7 @@ namespace march
 /** Store IMC data as a struct to prevent data overlap.*/
 struct IMCObject
 {
-  uint16_t address;            // in IMC memory (see IMC manual)
+  uint16_t address;           // in IMC memory (see IMC manual)
   uint8_t sub_index;          // sub index corresponding to PDO register (see IMC manual)
   uint8_t length;             // bits (see IMC manual)
   uint32_t combined_address;  // combine the address(hex), sub-index(hex) and length(hex)
@@ -23,7 +23,6 @@ struct IMCObject
   explicit IMCObject(uint16_t _address, uint8_t _sub_index, uint8_t _length)
     : address(_address), sub_index(_sub_index), length(_length)
   {
-
     uint32_t MSword = ((address & 0xFFFF) << 16);
     uint32_t LSword = ((sub_index & 0xFFFF) << 8) | (length & 0xFFFF);
 

--- a/march_hardware/include/march_hardware/PDOmap.h
+++ b/march_hardware/include/march_hardware/PDOmap.h
@@ -20,11 +20,11 @@ struct IMCObject
   uint8_t length;             // bits (see IMC manual)
   uint32_t combined_address;  // combine the address(hex), sub-index(hex) and length(hex)
 
-  explicit IMCObject(uint16_t _address, uint8_t _sub_index, uint8_t _length)
+  IMCObject(uint16_t _address, uint8_t _sub_index, uint8_t _length)
     : address(_address), sub_index(_sub_index), length(_length)
   {
-    uint32_t MSword = ((address & 0xFFFF) << 16);
-    uint32_t LSword = ((sub_index & 0xFFFF) << 8) | length;
+    uint32_t MSword = (address << 16);
+    uint32_t LSword = (sub_index << 8) | length;
 
     combined_address = (MSword | LSword);
   }

--- a/march_hardware/include/march_hardware/PDOmap.h
+++ b/march_hardware/include/march_hardware/PDOmap.h
@@ -24,7 +24,7 @@ struct IMCObject
     : address(_address), sub_index(_sub_index), length(_length)
   {
     uint32_t MSword = ((address & 0xFFFF) << 16);
-    uint32_t LSword = ((sub_index & 0xFFFF) << 8) | (length & 0xFFFF);
+    uint32_t LSword = ((sub_index & 0xFFFF) << 8) | length;
 
     combined_address = (MSword | LSword);
   }

--- a/march_hardware/src/PDOmap.cpp
+++ b/march_hardware/src/PDOmap.cpp
@@ -10,22 +10,22 @@
 namespace march
 {
 std::unordered_map<IMCObjectName, IMCObject> PDOmap::all_objects = {
-  { IMCObjectName::StatusWord, IMCObject(0x6041, 16) },
-  { IMCObjectName::ActualPosition, IMCObject(0x6064, 32) },
-  { IMCObjectName::ActualVelocity, IMCObject(0x6069, 32) },
-  { IMCObjectName::MotionErrorRegister, IMCObject(0x2000, 16) },
-  { IMCObjectName::DetailedErrorRegister, IMCObject(0x2002, 16) },
-  { IMCObjectName::DCLinkVoltage, IMCObject(0x2055, 16) },
-  { IMCObjectName::DriveTemperature, IMCObject(0x2058, 16) },
-  { IMCObjectName::ActualTorque, IMCObject(0x6077, 16) },
-  { IMCObjectName::CurrentLimit, IMCObject(0x207F, 16) },
-  { IMCObjectName::MotorPosition, IMCObject(0x2088, 32) },
-  { IMCObjectName::MotorVelocity, IMCObject(0x2087, 32) },
-  { IMCObjectName::ControlWord, IMCObject(0x6040, 16) },
-  { IMCObjectName::TargetPosition, IMCObject(0x607A, 32) },
-  { IMCObjectName::TargetTorque, IMCObject(0x6071, 16) },
-  { IMCObjectName::QuickStopDeceleration, IMCObject(0x6085, 32) },
-  { IMCObjectName::QuickStopOption, IMCObject(0x605A, 16) }
+  { IMCObjectName::StatusWord, IMCObject(0x6041, 0, 16) },
+  { IMCObjectName::ActualPosition, IMCObject(0x6064, 0, 32) },
+  { IMCObjectName::ActualVelocity, IMCObject(0x6069, 0, 32) },
+  { IMCObjectName::MotionErrorRegister, IMCObject(0x2000, 0, 16) },
+  { IMCObjectName::DetailedErrorRegister, IMCObject(0x2002, 0, 16) },
+  { IMCObjectName::DCLinkVoltage, IMCObject(0x2055, 0, 16) },
+  { IMCObjectName::DriveTemperature, IMCObject(0x2058, 0, 16) },
+  { IMCObjectName::ActualTorque, IMCObject(0x6077, 0, 16) },
+  { IMCObjectName::CurrentLimit, IMCObject(0x207F, 0, 16) },
+  { IMCObjectName::MotorPosition, IMCObject(0x2088, 0, 32) },
+  { IMCObjectName::MotorVelocity, IMCObject(0x2087, 0, 32) },
+  { IMCObjectName::ControlWord, IMCObject(0x6040, 0, 16) },
+  { IMCObjectName::TargetPosition, IMCObject(0x607A, 0, 32) },
+  { IMCObjectName::TargetTorque, IMCObject(0x6071, 0, 16) },
+  { IMCObjectName::QuickStopDeceleration, IMCObject(0x6085, 0, 32) },
+  { IMCObjectName::QuickStopOption, IMCObject(0x605A, 0, 16) }
 };
 
 void PDOmap::addObject(IMCObjectName object_name)

--- a/march_hardware/test/TestPDOmap.cpp
+++ b/march_hardware/test/TestPDOmap.cpp
@@ -53,3 +53,27 @@ TEST_F(PDOTest, ObjectCounts)
   ASSERT_EQ(1u, misoByteOffsets.count(march::IMCObjectName::CurrentLimit));
   ASSERT_EQ(0u, misoByteOffsets.count(march::IMCObjectName::DCLinkVoltage));
 }
+
+TEST_F(PDOTest, CombinedAddressConstruct)
+{
+  march::PDOmap pdoMap;
+
+  auto status_word = pdoMap.all_objects.find(march::IMCObjectName::StatusWord);
+  uint32_t combined_address = status_word->second.combined_address;
+
+  ASSERT_EQ(16u, (combined_address & 0xFF));
+  ASSERT_EQ(0u, ((combined_address >> 8) & 0xFF));
+  ASSERT_EQ(0x6041u, ((combined_address >> 16) & 0xFFFF));
+}
+
+TEST_F(PDOTest, CombinedAdressConstructWithSubindexValue)
+{
+  march::PDOmap pdoMap;
+
+  auto test_object = march::IMCObject(0x6060, 2, 16);
+  uint32_t combined_address = test_object.combined_address;
+
+  ASSERT_EQ(16u, (combined_address & 0xFF));
+  ASSERT_EQ(2u, ((combined_address >> 8) & 0xFF));
+  ASSERT_EQ(0x6060u, ((combined_address >> 16) & 0xFFFF));
+}


### PR DESCRIPTION
Closes PM-439

## Description
Added the sub index to the construction of the combined address which is used when defining the PDO's for every slave. I have chosen to add the sub index to every IMCobject instead of defining a default value. This way it would be most intuitive, The added tests verify that the combined address is constructed properly 

(_for more information about the construction of the PDO combined address look up page 39 in the IMC CoE manual_)

## Changes
* Added the subindex to the constrcutor of the IMCObject
* Added the subindex to the combinedAddress of an IMCObject
* Added tests to verify the combinedAddress