### PR TITLE
sort joint names alphabetically in yaml

### DIFF
--- a/march_hardware_builder/robots/march4.yaml
+++ b/march_hardware_builder/robots/march4.yaml
@@ -2,17 +2,17 @@ march4:
   ifName: enp2s0
   ecatCycleTime: 4
   joints:
-    - right_hip_aa:
+    - left_ankle:
         actuationMode: torque
         allowActuation: true
-        netNumber: 1
-        temperatureges: {slaveIndex: 7, byteOffset: 4}
+        netNumber: 8
+        temperatureges: {slaveIndex: 1, byteOffset: 0}
         imotioncube:
-          slaveIndex: 8
+          slaveIndex: 2
           absoluteEncoder:
             resolution: 12
-            minPositionIU: 3713
-            maxPositionIU: 4091
+            minPositionIU: 3641
+            maxPositionIU: 4082
           incrementalEncoder:
             resolution: 13
             transmission: 200
@@ -32,21 +32,6 @@ march4:
             resolution: 13
             transmission: 200
 
-    - right_hip_fe:
-        actuationMode: torque
-        allowActuation: true
-        netNumber: 2
-        temperatureges: {slaveIndex: 9, byteOffset: 0}
-        imotioncube:
-          slaveIndex: 10
-          absoluteEncoder:
-            resolution: 17
-            minPositionIU: 2053
-            maxPositionIU: 45617
-          incrementalEncoder:
-            resolution: 12
-            transmission: 101
-
     - left_hip_fe:
         actuationMode: torque
         allowActuation: true
@@ -58,21 +43,6 @@ march4:
             resolution: 17
             minPositionIU: 45699
             maxPositionIU: 89391
-          incrementalEncoder:
-            resolution: 12
-            transmission: 101
-
-    - right_knee:
-        actuationMode: torque
-        allowActuation: true
-        netNumber: 3
-        temperatureges: {slaveIndex: 9, byteOffset: 4}
-        imotioncube:
-          slaveIndex: 11
-          absoluteEncoder:
-            resolution: 17
-            minPositionIU: 41547
-            maxPositionIU: 85287
           incrementalEncoder:
             resolution: 12
             transmission: 101
@@ -107,17 +77,47 @@ march4:
             resolution: 13
             transmission: 200
 
-    - left_ankle:
+    - right_hip_aa:
         actuationMode: torque
         allowActuation: true
-        netNumber: 8
-        temperatureges: {slaveIndex: 1, byteOffset: 0}
+        netNumber: 1
+        temperatureges: {slaveIndex: 7, byteOffset: 4}
         imotioncube:
-          slaveIndex: 2
+          slaveIndex: 8
           absoluteEncoder:
             resolution: 12
-            minPositionIU: 3641
-            maxPositionIU: 4082
+            minPositionIU: 3713
+            maxPositionIU: 4091
           incrementalEncoder:
             resolution: 13
             transmission: 200
+
+    - right_hip_fe:
+        actuationMode: torque
+        allowActuation: true
+        netNumber: 2
+        temperatureges: {slaveIndex: 9, byteOffset: 0}
+        imotioncube:
+          slaveIndex: 10
+          absoluteEncoder:
+            resolution: 17
+            minPositionIU: 2053
+            maxPositionIU: 45617
+          incrementalEncoder:
+            resolution: 12
+            transmission: 101
+
+    - right_knee:
+        actuationMode: torque
+        allowActuation: true
+        netNumber: 3
+        temperatureges: {slaveIndex: 9, byteOffset: 4}
+        imotioncube:
+          slaveIndex: 11
+          absoluteEncoder:
+            resolution: 17
+            minPositionIU: 41547
+            maxPositionIU: 85287
+          incrementalEncoder:
+            resolution: 12
+            transmission: 101

--- a/march_hardware_builder/robots/march4.yaml
+++ b/march_hardware_builder/robots/march4.yaml
@@ -1,3 +1,4 @@
+# For convenience it is easiest if the joint order is maintained, it is chosen to sort the joints alphabetically.
 march4:
   ifName: enp2s0
   ecatCycleTime: 4


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->


## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->
Lately the sorting of the joints was only done before uploading them to the parameter server (#252). I thought this had no impact, but the joint names are in a different order in the `ImcState.msg` and `AfterLimitJointCommand`. This is a bit unfortunate for the RQT multiplot configurations and the conversion to csv. The easiest was to make sure the joints are used alphabetically again. I tried implementing the sort in the hardware builder, but the happens in place and because of the `unique_ptr` I didn't get it to work. Sorting in the yaml was easier. 
## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->
* Sort the joint names in the yaml alphabetically
<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
