### PR TITLE
Combine IMC errors into one big error

### DIFF
--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -449,11 +449,9 @@ bool MarchHardwareInterface::iMotionCubeStateCheck(size_t joint_index)
   march::IMotionCubeState imc_state = joint.getIMotionCubeState();
   if (imc_state.state == march::IMCState::FAULT)
   {
-    ROS_ERROR("IMotionCube of joint %s is in fault state %s \n", joint.getName().c_str(),
-              imc_state.state.getString().c_str());
-    ROS_ERROR("Detailed Error: %s (%s) \n", imc_state.detailedErrorDescription.c_str(),
-              imc_state.detailedError.c_str());
-    ROS_ERROR("Motion Error: %s (%s) \n", imc_state.motionErrorDescription.c_str(), imc_state.motionError.c_str());
+    ROS_ERROR("IMotionCube of joint %s is in fault state %s\nDetailed Error: %s (%s)\nMotion Error: %s (%s)",
+              joint.getName().c_str(), imc_state.state.getString().c_str(), imc_state.detailedErrorDescription.c_str(),
+              imc_state.detailedError.c_str(), imc_state.motionErrorDescription.c_str(), imc_state.motionError.c_str());
     return false;
   }
   return true;


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

## Description
Combined the errors that are printed when IMCs go into fault state so that there is less whitespace.

**before:**
```
[ERROR] IMotionCube of joint %s is in fault state %s

[ERROR] Detailed error: ...

[ERROR] Motion error: ...

```

**after:**
```
[ERROR] IMotionCube of joint %s is in fault state %s
Detailed error: ...
Motion error: ...
```

<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
