### PR TITLE
Fix/voltage velocity reading calculation

### DIFF
--- a/march_hardware/include/march_hardware/imotioncube/imotioncube.h
+++ b/march_hardware/include/march_hardware/imotioncube/imotioncube.h
@@ -60,9 +60,9 @@ public:
 
   ActuationMode getActuationMode() const;
 
-  virtual float getMotorCurrent();
+  virtual double getMotorCurrent();
   virtual float getIMCVoltage();
-  virtual float getMotorVoltage();
+  virtual double getMotorVoltage();
 
   void setControlWord(uint16_t control_word);
 

--- a/march_hardware/include/march_hardware/imotioncube/imotioncube_state.h
+++ b/march_hardware/include/march_hardware/imotioncube/imotioncube_state.h
@@ -130,9 +130,9 @@ public:
   IMCState state;
   std::string detailedErrorDescription;
   std::string motionErrorDescription;
-  float motorCurrent;
+  double motorCurrent;
   float IMCVoltage;
-  float motorVoltage;
+  double motorVoltage;
   int absoluteEncoderValue;
   int incrementalEncoderValue;
   double absoluteVelocity;

--- a/march_hardware/include/march_hardware/joint.h
+++ b/march_hardware/include/march_hardware/joint.h
@@ -127,8 +127,8 @@ private:
   const int net_number_;
   bool allow_actuation_ = false;
   float previous_imc_volt_ = 0.0;
-  float previous_motor_current_ = 0.0;
-  float previous_motor_volt_ = 0.0;
+  double previous_motor_current_ = 0.0;
+  double previous_motor_volt_ = 0.0;
   double previous_absolute_position_ = 0.0;
   double previous_incremental_position_ = 0.0;
   double previous_absolute_velocity_ = 0.0;

--- a/march_hardware/src/imotioncube/imotioncube.cpp
+++ b/march_hardware/src/imotioncube/imotioncube.cpp
@@ -304,7 +304,7 @@ float IMotionCube::getIMCVoltage()
 
 float IMotionCube::getMotorVoltage()
 {
-  return this->read16(this->miso_byte_offsets_.at(IMCObjectName::MotorVoltage)).ui;
+  return this->read16(this->miso_byte_offsets_.at(IMCObjectName::MotorVoltage)).i;
 }
 
 void IMotionCube::setControlWord(uint16_t control_word)

--- a/march_hardware/src/imotioncube/imotioncube.cpp
+++ b/march_hardware/src/imotioncube/imotioncube.cpp
@@ -280,14 +280,14 @@ uint16_t IMotionCube::getDetailedError()
   return this->read16(this->miso_byte_offsets_.at(IMCObjectName::DetailedErrorRegister)).ui;
 }
 
-float IMotionCube::getMotorCurrent()
+double IMotionCube::getMotorCurrent()
 {
   const float PEAK_CURRENT = 40.0;            // Peak current of iMC drive
   const float IU_CONVERSION_CONST = 65520.0;  // Conversion parameter, see Technosoft CoE programming manual
 
   int16_t motor_current_iu = this->read16(this->miso_byte_offsets_.at(IMCObjectName::ActualTorque)).i;
   return (2.0f * PEAK_CURRENT / IU_CONVERSION_CONST) *
-         static_cast<float>(motor_current_iu);  // Conversion to Amp, see Technosoft CoE programming manual
+         static_cast<double>(motor_current_iu);  // Conversion to Amp, see Technosoft CoE programming manual
 }
 
 float IMotionCube::getIMCVoltage()
@@ -302,7 +302,7 @@ float IMotionCube::getIMCVoltage()
          static_cast<float>(imc_voltage_iu);  // Conversion to Volt, see Technosoft CoE programming manual
 }
 
-float IMotionCube::getMotorVoltage()
+double IMotionCube::getMotorVoltage()
 {
   return this->read16(this->miso_byte_offsets_.at(IMCObjectName::MotorVoltage)).i;
 }

--- a/march_hardware/src/joint.cpp
+++ b/march_hardware/src/joint.cpp
@@ -307,8 +307,8 @@ bool Joint::receivedDataUpdate()
   // If imc voltage, motor current, and both encoders positions and velocities did not change,
   // we probably did not receive an update for this joint.
   float new_imc_volt = this->imc_->getIMCVoltage();
-  float new_motor_volt = this->imc_->getMotorVoltage();
-  float new_motor_current = this->imc_->getMotorCurrent();
+  double new_motor_volt = this->imc_->getMotorVoltage();
+  double new_motor_current = this->imc_->getMotorCurrent();
   double new_absolute_position = this->imc_->getAngleRadAbsolute();
   double new_incremental_position = this->imc_->getAngleRadIncremental();
   double new_absolute_velocity = this->imc_->getVelocityRadAbsolute();

--- a/march_hardware/src/joint.cpp
+++ b/march_hardware/src/joint.cpp
@@ -140,7 +140,7 @@ double Joint::getVoltageVelocity() const
   const double velocity_constant = 355;
   const double rpm_to_rad = M_PI / 30;
   const double electric_constant = velocity_constant * rpm_to_rad;
-  return (this->imc_->getMotorVoltage() + this->imc_->getMotorCurrent() * resistance) / electric_constant;
+  return (this->imc_->getMotorVoltage() + this->imc_->getMotorCurrent() * resistance) * electric_constant;
 }
 
 double Joint::getIncrementalPosition() const

--- a/march_hardware/test/mocks/mock_imotioncube.h
+++ b/march_hardware/test/mocks/mock_imotioncube.h
@@ -28,8 +28,8 @@ public:
   MOCK_METHOD0(getVelocityRadAbsolute, double());
 
   MOCK_METHOD0(getIMCVoltage, float());
-  MOCK_METHOD0(getMotorVoltage, float());
-  MOCK_METHOD0(getMotorCurrent, float());
+  MOCK_METHOD0(getMotorVoltage, double());
+  MOCK_METHOD0(getMotorCurrent, double());
 
   MOCK_METHOD1(actuateRad, void(double));
   MOCK_METHOD1(actuateTorque, void(int16_t));


### PR DESCRIPTION
## Description

Changed motor voltage reading to signed integer instead of unsigned integer. Also fixed faulty calculation of the velocity from the voltage. 

## Changes

* Changed motor voltage reading to signed integer instead of unsigned integer
* Fixed calculation of the velocity from voltage