### PR TITLE
Feature/pm 522 add warning soft limit

### DIFF
--- a/march_hardware_interface/config/march4/controllers.yaml
+++ b/march_hardware_interface/config/march4/controllers.yaml
@@ -33,26 +33,34 @@ march:
 
       constraints:
         left_ankle:
+          margin_soft_limit_error: 0.33
           trajectory: 0.305
           goal: 0.305
         left_hip_aa:
+          margin_soft_limit_error: 0.33
           trajectory: 0.305
           goal: 0.305
         left_hip_fe:
+          margin_soft_limit_error: 0.33
           trajectory: 0.305
           goal: 0.305
         left_knee:
+          margin_soft_limit_error: 0.33
           trajectory: 0.305
           goal: 0.305
         right_ankle:
+          margin_soft_limit_error: 0.33
           trajectory: 0.305
           goal: 0.305
         right_hip_aa:
+          margin_soft_limit_error: 0.33
           trajectory: 0.305
           goal: 0.305
         right_hip_fe:
+          margin_soft_limit_error: 0.33
           trajectory: 0.305
           goal: 0.305
         right_knee:
+          margin_soft_limit_error: 0.33
           trajectory: 0.305
           goal: 0.305

--- a/march_hardware_interface/config/march4/controllers.yaml
+++ b/march_hardware_interface/config/march4/controllers.yaml
@@ -33,34 +33,34 @@ march:
 
       constraints:
         left_ankle:
-          margin_soft_limit_error: 0.8
+          percent_soft_limit_error: 0.8
           trajectory: 0.305
           goal: 0.305
         left_hip_aa:
-          margin_soft_limit_error: 0.8
+          percent_soft_limit_error: 0.8
           trajectory: 0.305
           goal: 0.305
         left_hip_fe:
-          margin_soft_limit_error: 0.8
+          percent_soft_limit_error: 0.8
           trajectory: 0.305
           goal: 0.305
         left_knee:
-          margin_soft_limit_error: 0.8
+          percent_soft_limit_error: 0.8
           trajectory: 0.305
           goal: 0.305
         right_ankle:
-          margin_soft_limit_error: 0.8
+          percent_soft_limit_error: 0.8
           trajectory: 0.305
           goal: 0.305
         right_hip_aa:
-          margin_soft_limit_error: 0.8
+          percent_soft_limit_error: 0.8
           trajectory: 0.305
           goal: 0.305
         right_hip_fe:
-          margin_soft_limit_error: 0.8
+          percent_soft_limit_error: 0.8
           trajectory: 0.305
           goal: 0.305
         right_knee:
-          margin_soft_limit_error: 0.8
+          percent_soft_limit_error: 0.8
           trajectory: 0.305
           goal: 0.305

--- a/march_hardware_interface/config/march4/controllers.yaml
+++ b/march_hardware_interface/config/march4/controllers.yaml
@@ -33,34 +33,34 @@ march:
 
       constraints:
         left_ankle:
-          margin_soft_limit_error: 0.33
+          margin_soft_limit_error: 0.8
           trajectory: 0.305
           goal: 0.305
         left_hip_aa:
-          margin_soft_limit_error: 0.33
+          margin_soft_limit_error: 0.8
           trajectory: 0.305
           goal: 0.305
         left_hip_fe:
-          margin_soft_limit_error: 0.33
+          margin_soft_limit_error: 0.8
           trajectory: 0.305
           goal: 0.305
         left_knee:
-          margin_soft_limit_error: 0.33
+          margin_soft_limit_error: 0.8
           trajectory: 0.305
           goal: 0.305
         right_ankle:
-          margin_soft_limit_error: 0.33
+          margin_soft_limit_error: 0.8
           trajectory: 0.305
           goal: 0.305
         right_hip_aa:
-          margin_soft_limit_error: 0.33
+          margin_soft_limit_error: 0.8
           trajectory: 0.305
           goal: 0.305
         right_hip_fe:
-          margin_soft_limit_error: 0.33
+          margin_soft_limit_error: 0.8
           trajectory: 0.305
           goal: 0.305
         right_knee:
-          margin_soft_limit_error: 0.33
+          margin_soft_limit_error: 0.8
           trajectory: 0.305
           goal: 0.305

--- a/march_hardware_interface/config/march4/controllers.yaml
+++ b/march_hardware_interface/config/march4/controllers.yaml
@@ -33,34 +33,34 @@ march:
 
       constraints:
         left_ankle:
-          percent_soft_limit_error: 0.8
+          margin_soft_limit_error: 0.5
           trajectory: 0.305
           goal: 0.305
         left_hip_aa:
-          percent_soft_limit_error: 0.8
+          margin_soft_limit_error: 0.5
           trajectory: 0.305
           goal: 0.305
         left_hip_fe:
-          percent_soft_limit_error: 0.8
+          margin_soft_limit_error: 0.5
           trajectory: 0.305
           goal: 0.305
         left_knee:
-          percent_soft_limit_error: 0.8
+          margin_soft_limit_error: 0.5
           trajectory: 0.305
           goal: 0.305
         right_ankle:
-          percent_soft_limit_error: 0.8
+          margin_soft_limit_error: 0.5
           trajectory: 0.305
           goal: 0.305
         right_hip_aa:
-          percent_soft_limit_error: 0.8
+          margin_soft_limit_error: 0.5
           trajectory: 0.305
           goal: 0.305
         right_hip_fe:
-          percent_soft_limit_error: 0.8
+          margin_soft_limit_error: 0.5
           trajectory: 0.305
           goal: 0.305
         right_knee:
-          percent_soft_limit_error: 0.8
+          margin_soft_limit_error: 0.5
           trajectory: 0.305
           goal: 0.305

--- a/march_hardware_interface/include/march_hardware_interface/march_hardware_interface.h
+++ b/march_hardware_interface/include/march_hardware_interface/march_hardware_interface.h
@@ -77,8 +77,6 @@ public:
    * Construct the soft limit error based on the margin defined in the controller yaml and the soft limits and hard
    * limits in the URDF.
    */
-  static void getSoftJointLimitsError(const std::string& name, const urdf::JointConstSharedPtr& urdf_joint,
-                                      joint_limits_interface::SoftJointLimits& error_soft_limits);
 
 private:
   void uploadJointNames(ros::NodeHandle& nh) const;
@@ -94,6 +92,8 @@ private:
   void updateIMotionCubeState();
   void outsideLimitsCheck(size_t joint_index);
   bool iMotionCubeStateCheck(size_t joint_index);
+  static void getSoftJointLimitsError(const std::string& name, const urdf::JointConstSharedPtr& urdf_joint,
+                                      joint_limits_interface::SoftJointLimits& error_soft_limits);
 
   /* Limit of the change in effort command over one cycle, can be overridden by safety controller */
   static constexpr double MAX_EFFORT_CHANGE = 5000;

--- a/march_hardware_interface/include/march_hardware_interface/march_hardware_interface.h
+++ b/march_hardware_interface/include/march_hardware_interface/march_hardware_interface.h
@@ -68,7 +68,17 @@ public:
    */
   int getEthercatCycleTime() const;
 
+  /**
+   * Wait for received PDO.
+   */
   void waitForPdo();
+
+  /**
+   * Construct the soft limit error based on the margin defined in the controller yaml and the soft limits and hard
+   * limits in the URDF.
+   */
+  static void getSoftJointLimitsError(const std::string& name, const urdf::JointConstSharedPtr& urdf_joint,
+                                      joint_limits_interface::SoftJointLimits& error_soft_limits);
 
 private:
   void uploadJointNames(ros::NodeHandle& nh) const;
@@ -120,6 +130,7 @@ private:
   std::vector<double> joint_temperature_variance_;
 
   std::vector<joint_limits_interface::SoftJointLimits> soft_limits_;
+  std::vector<joint_limits_interface::SoftJointLimits> soft_limits_error_;
 
   PowerNetOnOffCommand power_net_on_off_command_;
   bool master_shutdown_allowed_command_ = false;

--- a/march_hardware_interface/include/march_hardware_interface/march_hardware_interface.h
+++ b/march_hardware_interface/include/march_hardware_interface/march_hardware_interface.h
@@ -73,11 +73,6 @@ public:
    */
   void waitForPdo();
 
-  /**
-   * Construct the soft limit error based on the margin defined in the controller yaml and the soft limits and hard
-   * limits in the URDF.
-   */
-
 private:
   void uploadJointNames(ros::NodeHandle& nh) const;
   /**

--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -504,7 +504,7 @@ void MarchHardwareInterface::getSoftJointLimitsError(const std::string& name,
   std::ostringstream param_name;
   std::ostringstream error_stream;
 
-  param_name << "/march/controller/trajectory/constraints/" << name << "/percent_soft_limit_error";
+  param_name << "/march/controller/trajectory/constraints/" << name << "/margin_soft_limit_error";
 
   if (!ros::param::has(param_name.str()))
   {

--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -515,7 +515,7 @@ void MarchHardwareInterface::getSoftJointLimitsError(const std::string& name,
   float margin;
   ros::param::param<float>(param_name.str(), margin, 0.0);
 
-  if (!urdf_joint || !urdf_joint->safety || !urdf_joint->limits || margin == 0.0)
+  if (!urdf_joint || !urdf_joint->safety || !urdf_joint->limits || margin <= 0.0 || margin > 1.0)
   {
     error_stream << "Could not construct the soft limits for joint: " << name;
     throw std::runtime_error(error_stream.str());

--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -470,21 +470,30 @@ bool MarchHardwareInterface::iMotionCubeStateCheck(size_t joint_index)
 void MarchHardwareInterface::outsideLimitsCheck(size_t joint_index)
 {
   march::Joint& joint = march_robot_->getJoint(joint_index);
+
   if (joint_position_[joint_index] < soft_limits_[joint_index].min_position ||
       joint_position_[joint_index] > soft_limits_[joint_index].max_position)
   {
-    ROS_ERROR_THROTTLE(1, "Joint %s is outside of its soft limits (%f, %f). Actual position: %f",
-                       joint.getName().c_str(), soft_limits_[joint_index].min_position,
-                       soft_limits_[joint_index].max_position, joint_position_[joint_index]);
-
-    if (joint.canActuate())
+    if (joint_position_[joint_index] < soft_limits_error_[joint_index].min_position ||
+        joint_position_[joint_index] > soft_limits_error_[joint_index].max_position)
     {
-      std::ostringstream error_stream;
-      error_stream << "Joint " << joint.getName() << " is out of its soft limits ("
-                   << soft_limits_[joint_index].min_position << ", " << soft_limits_[joint_index].max_position
-                   << "). Actual position: " << joint_position_[joint_index];
-      throw std::runtime_error(error_stream.str());
+      ROS_ERROR_THROTTLE(1, "Joint %s is outside of its error soft limits (%f, %f). Actual position: %f",
+                         joint.getName().c_str(), soft_limits_error_[joint_index].min_position,
+                         soft_limits_error_[joint_index].max_position, joint_position_[joint_index]);
+
+      if (joint.canActuate())
+      {
+        std::ostringstream error_stream;
+        error_stream << "Joint " << joint.getName() << " is out of its soft limits ("
+                     << soft_limits_[joint_index].min_position << ", " << soft_limits_[joint_index].max_position
+                     << "). Actual position: " << joint_position_[joint_index];
+        throw std::runtime_error(error_stream.str());
+      }
     }
+
+    ROS_WARN_THROTTLE(1, "Joint %s is outside of its soft limits (%f, %f). Actual position: %f",
+                      joint.getName().c_str(), soft_limits_[joint_index].min_position,
+                      soft_limits_[joint_index].max_position, joint_position_[joint_index]);
   }
 }
 

--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -44,15 +44,24 @@ bool MarchHardwareInterface::init(ros::NodeHandle& nh, ros::NodeHandle& /* robot
   this->reserveMemory();
 
   // Start ethercat cycle in the hardware
-  this->march_robot_->startEtherCAT(this->reset_imc_);
+  // this->march_robot_->startEtherCAT(this->reset_imc_);
 
   for (size_t i = 0; i < num_joints_; ++i)
   {
     const std::string name = this->march_robot_->getJoint(i).getName();
+
     SoftJointLimits soft_limits;
+    SoftJointLimits soft_limits_error;
+
     getSoftJointLimits(this->march_robot_->getUrdf().getJoint(name), soft_limits);
-    ROS_DEBUG("[%s] Soft limits set to (%f, %f)", name.c_str(), soft_limits.min_position, soft_limits.max_position);
+    getSoftJointLimitsError(name, this->march_robot_->getUrdf().getJoint(name), soft_limits_error);
+
+    ROS_DEBUG("[%s] ROS soft limits set to (%f, %f) and error limits set to (%f, %f)", name.c_str(),
+              soft_limits.min_position, soft_limits.max_position, soft_limits_error.min_position,
+              soft_limits_error.max_position);
+
     soft_limits_[i] = soft_limits;
+    soft_limits_error_[i] = soft_limits_error;
   }
 
   if (this->march_robot_->hasPowerDistributionboard())
@@ -298,6 +307,7 @@ void MarchHardwareInterface::reserveMemory()
   joint_temperature_.resize(num_joints_);
   joint_temperature_variance_.resize(num_joints_);
   soft_limits_.resize(num_joints_);
+  soft_limits_error_.resize(num_joints_);
 
   after_limit_joint_command_pub_->msg_.name.resize(num_joints_);
   after_limit_joint_command_pub_->msg_.position_command.resize(num_joints_);
@@ -476,4 +486,34 @@ void MarchHardwareInterface::outsideLimitsCheck(size_t joint_index)
       throw std::runtime_error(error_stream.str());
     }
   }
+}
+
+void MarchHardwareInterface::getSoftJointLimitsError(const std::string& name,
+                                                     const urdf::JointConstSharedPtr& urdf_joint,
+                                                     joint_limits_interface::SoftJointLimits& error_soft_limits)
+{
+  std::ostringstream param_name;
+  std::ostringstream error_stream;
+
+  param_name << "/march/controller/trajectory/constraints/" << name << "/margin_soft_limit_error";
+
+  if (!ros::param::has(param_name.str()))
+  {
+    error_stream << "Margin soft limits error of joint: " << name << " could not be found";
+    throw std::runtime_error(error_stream.str());
+  }
+
+  float margin;
+  ros::param::param<float>(param_name.str(), margin, 0.0);
+
+  if (!urdf_joint || !urdf_joint->safety || !urdf_joint->limits || margin == 0.0)
+  {
+    error_stream << "Could not construct the soft limits for joint: " << name;
+    throw std::runtime_error(error_stream.str());
+  }
+
+  error_soft_limits.min_position =
+      urdf_joint->limits->lower + ((urdf_joint->limits->lower - urdf_joint->safety->soft_lower_limit) * margin);
+  error_soft_limits.max_position =
+      urdf_joint->limits->upper - ((urdf_joint->limits->upper - urdf_joint->safety->soft_upper_limit) * margin);
 }

--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -44,7 +44,7 @@ bool MarchHardwareInterface::init(ros::NodeHandle& nh, ros::NodeHandle& /* robot
   this->reserveMemory();
 
   // Start ethercat cycle in the hardware
-  // this->march_robot_->startEtherCAT(this->reset_imc_);
+  this->march_robot_->startEtherCAT(this->reset_imc_);
 
   for (size_t i = 0; i < num_joints_; ++i)
   {
@@ -522,7 +522,7 @@ void MarchHardwareInterface::getSoftJointLimitsError(const std::string& name,
   }
 
   error_soft_limits.min_position =
-      urdf_joint->limits->lower + ((urdf_joint->limits->lower - urdf_joint->safety->soft_lower_limit) * margin);
+      urdf_joint->limits->lower + ((urdf_joint->safety->soft_lower_limit - urdf_joint->limits->lower) * margin);
   error_soft_limits.max_position =
       urdf_joint->limits->upper - ((urdf_joint->limits->upper - urdf_joint->safety->soft_upper_limit) * margin);
 }

--- a/march_hardware_interface/src/march_hardware_interface.cpp
+++ b/march_hardware_interface/src/march_hardware_interface.cpp
@@ -504,7 +504,7 @@ void MarchHardwareInterface::getSoftJointLimitsError(const std::string& name,
   std::ostringstream param_name;
   std::ostringstream error_stream;
 
-  param_name << "/march/controller/trajectory/constraints/" << name << "/margin_soft_limit_error";
+  param_name << "/march/controller/trajectory/constraints/" << name << "/percent_soft_limit_error";
 
   if (!ros::param::has(param_name.str()))
   {


### PR DESCRIPTION
Closes PM-522

## Description
This PR create a new _error soft limit_ to prevent the exoskeleton from raising an exception when it is just over the soft limits defined in the URDF. It has a new parameter for every joint in the controller.yaml which defines the percentage after which the soft limit should throw an error. When it is inside the _soft_limits_ defined in the URDF but **not** over the _error_soft_limit_ ROS will try and compensate the error and move to an acceptable position.

## Changes
* New error soft limit percentage parameter in controller.yaml for every joint
* Created a soft limit error vector to define the upper and lower error for every joint
* Used the new error soft limit in the outsideLimitsCheck in the hardware interface
