### PR TITLE
Replace spawner with controller_manger spawn

### DIFF
--- a/march_hardware_interface/launch/hardware.launch
+++ b/march_hardware_interface/launch/hardware.launch
@@ -9,8 +9,9 @@
     <group ns="march">
         <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
 
-        <node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="true"
-              args="controller/joint_state controller/temperature_sensor controller/trajectory"
+        <node name="controller_spawner" pkg="controller_manager" type="controller_manager" respawn="false"
+              output="screen"
+              args="spawn controller/joint_state controller/temperature_sensor controller/trajectory"
         />
 
         <node


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

## Description

## Changes
In PM-529, I discovered that the way we spawn and unload controllers was not the best way. The controller spawner we use in the launch file, loads, starts and finally tries to unload them when the spawner is shutdown. However, the controller manager always shuts down faster than the controller spawner can even try to unload them. That describes the warning that says the controller spawner could not unload the controllers. I have now replaced the spawner with just a launcher script, which loads, starts and then forgets about them.
