### PR TITLE
Fix: initialize variables

### DIFF
--- a/march_joint_inertia_controller/src/inertia_estimator.cpp
+++ b/march_joint_inertia_controller/src/inertia_estimator.cpp
@@ -103,8 +103,8 @@ void InertiaEstimator::applyButter()
 {
   // Apply a sixth order Butterworth filter over the effort and acceleration signals
   int i = 0;
-  double x;
-  double x_n;
+  double x = 0.0;
+  double x_n = 0.0;
 
   for (const auto& so : sos_)
   {


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

## Description
When building in release mode, it gives an error here stating that it could be used uninitialized, so I initialized it to 0.0.

## Changes
* Initialize doubles to 0.0
